### PR TITLE
🔄 Refactor CLI commands and update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 readme:
-	python -m cli.cli --direct -f prompts/README.md.jinja2 -o README.md
+	python -m cli.cli task --direct -f prompts/README.md.jinja2 -o README.md
 pr-description:
-	python -m cli.cli -f prompts/generate_pr_description.md.jinja2
+	python -m cli.cli task -f prompts/generate_pr_description.md.jinja2

--- a/README.md
+++ b/README.md
@@ -25,37 +25,37 @@ Open a terminal and `ls` into a repository you have [installed](https://github.c
 In your repository, use the `pilot` command:
 
 ```bash
-pilot "Tell me about this project!"
+pilot task "Tell me about this project!"
 ```
 
 **📝 Ask PR Pilot to edit a local file for you:**
 
 ```bash
-pilot --edit cli/cli.py "Make sure all functions and classes have docstrings."
+pilot edit cli/cli.py "Make sure all functions and classes have docstrings."
 ```
 
 **⚡ Generate code quickly and save it as a file:**
 
 ```bash
-pilot -o test_utils.py --code "Write some unit tests for the utils.py file."
+pilot task -o test_utils.py --code "Write some unit tests for the utils.py file."
 ```
 
 **🔍 Capture part of your screen and add it to a prompt:**
 
 ```bash
-pilot -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
+pilot task -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
 ```
 
 **📊 Get an organized view of your Github issues:**
 
 ```bash
-pilot "Find all open Github issues labeled as 'bug', categorize and prioritize them"
+pilot task "Find all open Github issues labeled as 'bug', categorize and prioritize them"
 ```
 
 **📝 Generate parts of your documentation with a [template](./prompts/README.md.jinja2):**
 
 ```bash
-pilot --direct -f prompts/README.md.jinja2 -o README.md
+pilot task --direct -f prompts/README.md.jinja2 -o README.md
 ```
 
 To learn more about templates, check out the [prompts](./prompts) directory.
@@ -85,39 +85,80 @@ steps:
     template: doc_instructions.md
 ```
 
-Run it with `pilot --plan document_cli.yaml`.
+Run it with `pilot plan document_cli.yaml`.
 
 ### ⚙️ Options and Parameters
 
-You can customize your interact with PR Pilot using parameters and options:
+The CLI has global parameters and options that can be used to customize its behavior.
+
 
 ```bash
-Usage: pilot [OPTIONS] [PROMPT]...
+Usage: pilot [OPTIONS] COMMAND [ARGS]...
 
-  Create a new task for PR Pilot - https://docs.pr-pilot.ai
+  PR Pilot CLI - https://docs.pr-pilot.ai
 
 Options:
   --wait / --no-wait        Wait for PR Pilot to finish the task.
   --repo TEXT               Github repository in the format owner/repo.
-  --snap                    Select a portion of your screen to add as an image
-                            to the task.
-  -p, --plan PATH           Path to YAML file containing step-by-step plan for
-                            PR Pilot.
-  -e, --edit PATH           Let PR Pilot edit a file for you.
   --spinner / --no-spinner  Display a loading indicator.
   --quiet                   Disable all output on the terminal.
-  --cheap                   Use the cheapest GPT model (gpt-3.5-turbo)
-  --code                    Optimize prompt and settings for generating code
-  -f, --file PATH           Generate prompt from a template file.
-  --direct                  Do not feed the rendered template as a prompt into
-                            PR Pilot, but render it directly as output.
-  -o, --output PATH         Output file for the result.
   -m, --model TEXT          GPT model to use.
   -b, --branch TEXT         Run the task on a specific branch.
   --sync                    Run task on your current branch and pull PR
                             Pilot's changes when done.
   --debug                   Display debug information.
   --help                    Show this message and exit.
+
+Commands:
+  edit  Let PR Pilot edit a file for you.
+  plan  Let PR Pilot execute a plan for you.
+  task  Create a new task for PR Pilot
+
+```
+
+Then there are three sub-commands.
+
+Create a new task for PR Pilot using a prompt or prompt template.
+
+```bash
+Usage: pilot task [OPTIONS] [PROMPT]...
+
+  Create a new task for PR Pilot
+
+Options:
+  --snap             Select a portion of your screen to add as an image to the
+                     task.
+  --cheap            Use the cheapest GPT model (gpt-3.5-turbo)
+  --code             Optimize prompt and settings for generating code
+  -f, --file PATH    Generate prompt from a template file.
+  --direct           Do not feed the rendered template as a prompt into PR
+                     Pilot, but render it directly as output.
+  -o, --output PATH  Output file for the result.
+  --help             Show this message and exit.
+
+```
+
+Edit a local file using PR Pilot.
+
+```bash
+Usage: pilot edit [OPTIONS] FILE_PATH PROMPT
+
+  Let PR Pilot edit a file for you.
+
+Options:
+  --help  Show this message and exit.
+
+```
+
+Run a step-by-step plan with PR Pilot.
+
+```bash
+Usage: pilot plan [OPTIONS] FILE_PATH
+
+  Let PR Pilot execute a plan for you.
+
+Options:
+  --help  Show this message and exit.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ Usage: pilot [OPTIONS] COMMAND [ARGS]...
 
   PR Pilot CLI - https://docs.pr-pilot.ai
 
+  Delegate routine work to AI with confidence and predictability.
+
+  Examples:
+
+  - 📸 Create a Bootstrap5 component based on a screenshot:
+    pilot task -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
+
+  - 🛠️ Refactor and clean up code:
+    pilot edit main.js "Break up large functions, organize the file and add comments."
+
+  - 🔄 Interact across services and tools:
+    pilot task "Find all open Linear and Github issues labeled as 'bug' and send them to the #bugs Slack channel."
+
 Options:
   --wait / --no-wait        Wait for PR Pilot to finish the task.
   --repo TEXT               Github repository in the format owner/repo.
@@ -110,52 +123,74 @@ Options:
   --help                    Show this message and exit.
 
 Commands:
-  edit  Let PR Pilot edit a file for you.
-  plan  Let PR Pilot execute a plan for you.
-  task  Create a new task for PR Pilot
+  edit  ✍️ Let PR Pilot edit a file for you.
+  plan  📋 Let PR Pilot execute a plan for you.
+  task  🛠️Create a new task for PR Pilot.
 
 ```
 
-Then there are three sub-commands.
+#### Commands
 
-Create a new task for PR Pilot using a prompt or prompt template.
+Work Delegation:
 
 ```bash
 Usage: pilot task [OPTIONS] [PROMPT]...
 
-  Create a new task for PR Pilot
+  🛠️Create a new task for PR Pilot.
+
+  Examples:
+
+  - Generate unit tests for a Python file:
+    pilot task -o test_utils.py --code "Write some unit tests for the utils.py file."
+
+  - Create a Bootstrap5 component based on a screenshot:
+    pilot task -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
+
+  - Send a list of all bug issues to Slack:
+    pilot task "Find all open Github issues labeled as 'bug' and send them to the #bugs Slack channel."
 
 Options:
-  --snap             Select a portion of your screen to add as an image to the
-                     task.
-  --cheap            Use the cheapest GPT model (gpt-3.5-turbo)
-  --code             Optimize prompt and settings for generating code
-  -f, --file PATH    Generate prompt from a template file.
-  --direct           Do not feed the rendered template as a prompt into PR
+  --snap             📸 Select a portion of your screen to add as an image to
+                     the task.
+  --cheap            💸 Use the cheapest GPT model (gpt-3.5-turbo)
+  --code             💻 Optimize prompt and settings for generating code
+  -f, --file PATH    📂 Generate prompt from a template file.
+  --direct           🔄 Do not feed the rendered template as a prompt into PR
                      Pilot, but render it directly as output.
-  -o, --output PATH  Output file for the result.
+  -o, --output PATH  💾 Output file for the result.
   --help             Show this message and exit.
 
 ```
 
-Edit a local file using PR Pilot.
+In-Place Editing:
 
 ```bash
 Usage: pilot edit [OPTIONS] FILE_PATH PROMPT
 
-  Let PR Pilot edit a file for you.
+  ✍️ Let PR Pilot edit a file for you.
+
+  Examples:
+
+  - ✍️ Quickly add docstrings to a Python file:
+    pilot edit main.py "Add docstrings for all classes, functions and parameters."
+
+  - ♻️ Refactor and clean up code:
+    pilot edit main.js "Break up large functions, organize the file and add comments."
+
+  - 🧩 Implement placeholders:
+    pilot edit "I left placeholder comments in the file. Please replace them with the actual code."
 
 Options:
   --help  Show this message and exit.
 
 ```
 
-Run a step-by-step plan with PR Pilot.
+For more complex tasks:
 
 ```bash
 Usage: pilot plan [OPTIONS] FILE_PATH
 
-  Let PR Pilot execute a plan for you.
+  📋 Let PR Pilot execute a plan for you.
 
 Options:
   --help  Show this message and exit.

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -11,54 +11,114 @@ from cli.task_runner import TaskRunner
 from cli.util import pull_branch_changes
 
 
-@click.command()
+@click.group()
 @click.option('--wait/--no-wait', is_flag=True, default=True, help='Wait for PR Pilot to finish the task.')
 @click.option('--repo', help='Github repository in the format owner/repo.', required=False)
-@click.option('--snap', is_flag=True, help='Select a portion of your screen to add as an image to the task.')
-@click.option('--plan', '-p', type=click.Path(exists=True), help='Path to YAML file containing step-by-step plan for PR Pilot.')
-@click.option('--edit', '-e', type=click.Path(exists=True), help='Let PR Pilot edit a file for you.')
 @click.option('--spinner/--no-spinner', is_flag=True, default=True, help='Display a loading indicator.')
 @click.option('--quiet', is_flag=True, default=False, help='Disable all output on the terminal.')
+@click.option('--model', '-m', help='GPT model to use.', default=DEFAULT_MODEL)
+@click.option('--branch', '-b', help='Run the task on a specific branch.', required=False, default=None)
+@click.option('--sync', is_flag=True, default=False, help='Run task on your current branch and pull PR Pilot\'s changes when done.')
+@click.option('--debug', is_flag=True, default=False, help='Display debug information.')
+@click.pass_context
+def main(ctx, wait, repo, spinner, quiet, model, branch, sync, debug):
+    """PR Pilot CLI - https://docs.pr-pilot.ai"""
+    ctx.ensure_object(dict)
+    ctx.obj['wait'] = wait
+    ctx.obj['repo'] = repo
+    ctx.obj['spinner'] = spinner
+    ctx.obj['quiet'] = quiet
+    ctx.obj['model'] = model
+    ctx.obj['branch'] = branch
+    ctx.obj['sync'] = sync
+    ctx.obj['debug'] = debug
+
+
+@click.command()
+@click.option('--snap', is_flag=True, help='Select a portion of your screen to add as an image to the task.')
 @click.option('--cheap', is_flag=True, default=False, help=f'Use the cheapest GPT model ({CHEAP_MODEL})')
 @click.option('--code', is_flag=True, default=False, help='Optimize prompt and settings for generating code')
 @click.option('--file', '-f', type=click.Path(exists=True), help='Generate prompt from a template file.')
 @click.option('--direct', is_flag=True, default=False,
               help='Do not feed the rendered template as a prompt into PR Pilot, but render it directly as output.')
 @click.option('--output', '-o', type=click.Path(exists=False), help='Output file for the result.')
-@click.option('--model', '-m', help='GPT model to use.', default=DEFAULT_MODEL)
-@click.option('--branch', '-b', help='Run the task on a specific branch.', required=False, default=None)
-@click.option('--sync', is_flag=True, default=False, help='Run task on your current branch and pull PR Pilot\'s changes when done.')
-@click.option('--debug', is_flag=True, default=False, help='Display debug information.')
 @click.argument('prompt', nargs=-1)
-def main(wait, repo, snap, plan, edit, spinner, quiet, cheap, code, file, direct, output, model, branch, sync, debug, prompt):
-    """Create a new task for PR Pilot - https://docs.pr-pilot.ai"""
-
+@click.pass_context
+def task(ctx, snap, cheap, code, file, direct, output, prompt):
+    """Create a new task for PR Pilot"""
     console = Console()
-    show_spinner = spinner and not quiet
-    status_indicator = StatusIndicator(spinner=show_spinner, messages=not quiet, console=console)
+    show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
+    status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
 
     try:
-        if plan is not None:
-            runner = PlanExecutor(plan, status_indicator)
-            runner.run(wait, repo, edit, quiet, model, debug, prompt)
-            if sync:
-                pull_branch_changes(status_indicator, console, branch, debug)
-            return
-
-        if sync and not branch:
+        if ctx.obj['sync'] and not ctx.obj['branch']:
             # Get current branch from git
-            branch = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
+            ctx.obj['branch'] = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
 
         runner = TaskRunner(status_indicator)
-        runner.run_task(wait, repo, snap, edit, quiet, cheap, code, file, direct, output, model, debug, prompt, branch=branch)
-        if sync:
-            pull_branch_changes(status_indicator, console, branch, debug)
+        runner.run_task(ctx.obj['wait'], ctx.obj['repo'], snap, None, ctx.obj['quiet'], cheap, code, file, direct, output, ctx.obj['model'], ctx.obj['debug'], prompt, branch=ctx.obj['branch'])
+        if ctx.obj['sync']:
+            pull_branch_changes(status_indicator, console, ctx.obj['branch'], ctx.obj['debug'])
 
     except Exception as e:
         status_indicator.fail()
         console.print(f"[bold red]An error occurred:[/bold red] {type(e)} {str(e)}")
     finally:
         status_indicator.stop()
+
+
+@click.command()
+@click.argument('file_path', type=click.Path(exists=True))
+@click.argument('prompt')
+@click.pass_context
+def edit(ctx, file_path, prompt):
+    """Let PR Pilot edit a file for you."""
+    console = Console()
+    show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
+    status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
+
+    try:
+        if ctx.obj['sync'] and not ctx.obj['branch']:
+            # Get current branch from git
+            ctx.obj['branch'] = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
+
+        runner = TaskRunner(status_indicator)
+        runner.run_task(ctx.obj['wait'], ctx.obj['repo'], None, file_path, ctx.obj['quiet'], False, False, None, False, None, ctx.obj['model'], ctx.obj['debug'], prompt, branch=ctx.obj['branch'])
+        if ctx.obj['sync']:
+            pull_branch_changes(status_indicator, console, ctx.obj['branch'], ctx.obj['debug'])
+
+    except Exception as e:
+        status_indicator.fail()
+        console.print(f"[bold red]An error occurred:[/bold red] {type(e)} {str(e)}")
+    finally:
+        status_indicator.stop()
+
+
+@click.command()
+@click.argument('file_path', type=click.Path(exists=True))
+@click.pass_context
+def plan(ctx, file_path):
+    """Let PR Pilot execute a plan for you."""
+    console = Console()
+    show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
+    status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
+
+    try:
+        runner = PlanExecutor(file_path, status_indicator)
+        runner.run(ctx.obj['wait'], ctx.obj['repo'], ctx.obj['quiet'], ctx.obj['model'], ctx.obj['debug'])
+        if ctx.obj['sync']:
+            pull_branch_changes(status_indicator, console, ctx.obj['branch'], ctx.obj['debug'])
+
+    except Exception as e:
+        status_indicator.fail()
+        console.print(f"[bold red]An error occurred:[/bold red] {type(e)} {str(e)}")
+    finally:
+        status_indicator.stop()
+
+
+main.add_command(task)
+main.add_command(edit)
+main.add_command(plan)
 
 
 if __name__ == '__main__':

--- a/cli/commands/edit.py
+++ b/cli/commands/edit.py
@@ -1,0 +1,51 @@
+import os
+
+import click
+from rich.console import Console
+
+from cli.status_indicator import StatusIndicator
+from cli.task_runner import TaskRunner
+from cli.util import pull_branch_changes
+
+
+@click.command()
+@click.argument('file_path', type=click.Path(exists=True))
+@click.argument('prompt')
+@click.pass_context
+def edit(ctx, file_path, prompt):
+    """✍️ Let PR Pilot edit a file for you.
+
+    Examples:
+
+    \b
+    - ✍️ Quickly add docstrings to a Python file:
+      pilot edit main.py "Add docstrings for all classes, functions and parameters."
+
+    \b
+    - ♻️ Refactor and clean up code:
+      pilot edit main.js "Break up large functions, organize the file and add comments."
+
+    \b
+    - 🧩 Implement placeholders:
+      pilot edit "I left placeholder comments in the file. Please replace them with the actual code."
+
+    """
+    console = Console()
+    show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
+    status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
+
+    try:
+        if ctx.obj['sync'] and not ctx.obj['branch']:
+            # Get current branch from git
+            ctx.obj['branch'] = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
+
+        runner = TaskRunner(status_indicator)
+        runner.run_task(ctx.obj['wait'], ctx.obj['repo'], None, file_path, ctx.obj['quiet'], False, False, None, False, None, ctx.obj['model'], ctx.obj['debug'], prompt, branch=ctx.obj['branch'])
+        if ctx.obj['sync']:
+            pull_branch_changes(status_indicator, console, ctx.obj['branch'], ctx.obj['debug'])
+
+    except Exception as e:
+        status_indicator.fail()
+        console.print(f"[bold red]An error occurred:[/bold red] {type(e)} {str(e)}")
+    finally:
+        status_indicator.stop()

--- a/cli/commands/plan.py
+++ b/cli/commands/plan.py
@@ -23,6 +23,8 @@ def plan(ctx, file_path):
 
     except Exception as e:
         status_indicator.fail()
+        if ctx.obj['debug']:
+            raise e
         console.print(f"[bold red]An error occurred:[/bold red] {type(e)} {str(e)}")
     finally:
         status_indicator.stop()

--- a/cli/commands/plan.py
+++ b/cli/commands/plan.py
@@ -1,0 +1,28 @@
+import click
+from rich.console import Console
+
+from cli.plan_executor import PlanExecutor
+from cli.status_indicator import StatusIndicator
+from cli.util import pull_branch_changes
+
+
+@click.command()
+@click.argument('file_path', type=click.Path(exists=True))
+@click.pass_context
+def plan(ctx, file_path):
+    """📋 Let PR Pilot execute a plan for you."""
+    console = Console()
+    show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
+    status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
+
+    try:
+        runner = PlanExecutor(file_path, status_indicator)
+        runner.run(ctx.obj['wait'], ctx.obj['repo'], ctx.obj['quiet'], ctx.obj['model'], ctx.obj['debug'])
+        if ctx.obj['sync']:
+            pull_branch_changes(status_indicator, console, ctx.obj['branch'], ctx.obj['debug'])
+
+    except Exception as e:
+        status_indicator.fail()
+        console.print(f"[bold red]An error occurred:[/bold red] {type(e)} {str(e)}")
+    finally:
+        status_indicator.stop()

--- a/cli/commands/task.py
+++ b/cli/commands/task.py
@@ -1,0 +1,57 @@
+import os
+
+import click
+from rich.console import Console
+
+from cli.constants import CHEAP_MODEL
+from cli.status_indicator import StatusIndicator
+from cli.task_runner import TaskRunner
+from cli.util import pull_branch_changes
+
+
+@click.command()
+@click.option('--snap', is_flag=True, help='📸 Select a portion of your screen to add as an image to the task.')
+@click.option('--cheap', is_flag=True, default=False, help=f'💸 Use the cheapest GPT model ({CHEAP_MODEL})')
+@click.option('--code', is_flag=True, default=False, help='💻 Optimize prompt and settings for generating code')
+@click.option('--file', '-f', type=click.Path(exists=True), help='📂 Generate prompt from a template file.')
+@click.option('--direct', is_flag=True, default=False,
+              help='🔄 Do not feed the rendered template as a prompt into PR Pilot, but render it directly as output.')
+@click.option('--output', '-o', type=click.Path(exists=False), help='💾 Output file for the result.')
+@click.argument('prompt', nargs=-1)
+@click.pass_context
+def task(ctx, snap, cheap, code, file, direct, output, prompt):
+    """🛠️Create a new task for PR Pilot.
+
+    Examples:
+
+    \b
+    - Generate unit tests for a Python file:
+      pilot task -o test_utils.py --code "Write some unit tests for the utils.py file."
+
+    \b
+    - Create a Bootstrap5 component based on a screenshot:
+      pilot task -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
+
+    \b
+    - Send a list of all bug issues to Slack:
+      pilot task "Find all open Github issues labeled as 'bug' and send them to the #bugs Slack channel."
+    """
+    console = Console()
+    show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
+    status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
+
+    try:
+        if ctx.obj['sync'] and not ctx.obj['branch']:
+            # Get current branch from git
+            ctx.obj['branch'] = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
+
+        runner = TaskRunner(status_indicator)
+        runner.run_task(ctx.obj['wait'], ctx.obj['repo'], snap, None, ctx.obj['quiet'], cheap, code, file, direct, output, ctx.obj['model'], ctx.obj['debug'], prompt, branch=ctx.obj['branch'])
+        if ctx.obj['sync']:
+            pull_branch_changes(status_indicator, console, ctx.obj['branch'], ctx.obj['debug'])
+
+    except Exception as e:
+        status_indicator.fail()
+        console.print(f"[bold red]An error occurred:[/bold red] {type(e)} {str(e)}")
+    finally:
+        status_indicator.stop()

--- a/cli/plan_executor.py
+++ b/cli/plan_executor.py
@@ -26,16 +26,14 @@ class PlanExecutor:
         self.pr_number = None
         self.responses = []
 
-    def run(self, wait, repo, edit, quiet, model, debug, prompt):
+    def run(self, wait, repo, quiet, model, debug):
         """Run all steps in a given plan
 
         :param wait: Wait for PR Pilot to finish the plan
         :param repo: Github repository in the format owner/repo
-        :param edit: Let PR Pilot edit a file for you
         :param quiet: Disable all output on the terminal
         :param model: GPT model to use
         :param debug: Display debug information
-        :param prompt: Prompt for the task
 
         """
         console = Console()
@@ -75,7 +73,7 @@ class PlanExecutor:
 
             prompt = task.get('prompt')
             task_runner = TaskRunner(self.status_indicator)
-            finished_task = task_runner.run_task(wait, repo, snap, edit, quiet, cheap, code, template_file_path, direct, output_file, model, debug, wrapped_prompt, branch=branch, pr_number=self.pr_number)
+            finished_task = task_runner.run_task(wait, repo, snap, False, quiet, cheap, code, template_file_path, direct, output_file, model, debug, wrapped_prompt, branch=branch, pr_number=self.pr_number)
             if not finished_task:
                 raise ValueError('Task failed')
             self.responses.append(finished_task.result)

--- a/cli/plan_executor.py
+++ b/cli/plan_executor.py
@@ -62,7 +62,7 @@ class PlanExecutor:
             for i, response in enumerate(self.responses):
                 previous_responses += f"## Result of Sub-task {i + 1}\n\n{response}\n\n"
             wrapped_prompt = (f"We are working on a main task that contains a list of sub-tasks. This is sub-task {current_task} / {num_tasks}\n\n---\n\n"
-                              f"# Main Task {self.name}\n\n{prompt}\n\n"
+                              f"# Main Task {self.name}\n\n{self.plan.get('prompt')}\n\n"
                               f"# Results of previous sub-tasks\n\n{previous_responses}\n\n"
                               f"# Current Sub-task: {task.get('name')}\n\n{task.get('prompt')}\n\n---\n\n"
                               f"Follow the instructions of the current sub-task! Respond with a compact bullet list of your actions.")
@@ -71,7 +71,6 @@ class PlanExecutor:
                 console.print(Markdown(wrapped_prompt))
                 console.line()
 
-            prompt = task.get('prompt')
             task_runner = TaskRunner(self.status_indicator)
             finished_task = task_runner.run_task(wait, repo, snap, False, quiet, cheap, code, template_file_path, direct, output_file, model, debug, wrapped_prompt, branch=branch, pr_number=self.pr_number)
             if not finished_task:
@@ -79,4 +78,4 @@ class PlanExecutor:
             self.responses.append(finished_task.result)
             if self.pr_number is None and finished_task.pr_number and not quiet:
                 console.print(f"Found new pull request! All subsequent tasks will run on PR #{finished_task.pr_number}")
-            self.pr_number = int(finished_task.pr_number)
+            self.pr_number = int(finished_task.pr_number) if finished_task.pr_number else None

--- a/examples/implementation-plan/README.md
+++ b/examples/implementation-plan/README.md
@@ -9,5 +9,5 @@ Plans can be used to break down more complex tasks into smaller steps.
 This plan demonstrates how to implement the Quicksort algorithm in Python. 
 
 ```shell
-pilot --plan quicksort.yaml
+pilot plan quicksort.yaml
 ```

--- a/prompts/README.md.jinja2
+++ b/prompts/README.md.jinja2
@@ -25,37 +25,37 @@ Open a terminal and `ls` into a repository you have [installed](https://github.c
 In your repository, use the `pilot` command:
 
 ```bash
-pilot "Tell me about this project!"
+pilot task "Tell me about this project!"
 ```
 
 **📝 Ask PR Pilot to edit a local file for you:**
 
 ```bash
-pilot --edit cli/cli.py "Make sure all functions and classes have docstrings."
+pilot edit cli/cli.py "Make sure all functions and classes have docstrings."
 ```
 
 **⚡ Generate code quickly and save it as a file:**
 
 ```bash
-pilot -o test_utils.py --code "Write some unit tests for the utils.py file."
+pilot task -o test_utils.py --code "Write some unit tests for the utils.py file."
 ```
 
 **🔍 Capture part of your screen and add it to a prompt:**
 
 ```bash
-pilot -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
+pilot task -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
 ```
 
 **📊 Get an organized view of your Github issues:**
 
 ```bash
-pilot "Find all open Github issues labeled as 'bug', categorize and prioritize them"
+pilot task "Find all open Github issues labeled as 'bug', categorize and prioritize them"
 ```
 
 **📝 Generate parts of your documentation with a [template](./prompts/README.md.jinja2):**
 
 ```bash
-pilot --direct -f prompts/README.md.jinja2 -o README.md
+pilot task --direct -f prompts/README.md.jinja2 -o README.md
 ```
 
 To learn more about templates, check out the [prompts](./prompts) directory.
@@ -85,14 +85,41 @@ steps:
     template: doc_instructions.md
 ```
 
-Run it with `pilot --plan document_cli.yaml`.
+Run it with `pilot plan document_cli.yaml`.
 
 ### ⚙️ Options and Parameters
 
-You can customize your interact with PR Pilot using parameters and options:
+The CLI has global parameters and options that can be used to customize its behavior.
+
 
 ```bash
 {{ sh('python -m cli.cli --help') }}
+```
+
+Then there are three sub-commands:
+
+#### `pilot task PROMPT`
+
+Create a new task for PR Pilot using a prompt or prompt template.
+
+```bash
+{{ sh('python -m cli.cli task --help') }}
+```
+
+#### `pilot edit FILE PROMPT`
+
+Edit a local file using PR Pilot.
+
+```bash
+{{ sh('python -m cli.cli edit --help') }}
+```
+
+#### `pilot plan PLAN`
+
+Run a step-by-step plan with PR Pilot.
+
+```bash
+{{ sh('python -m cli.cli plan --help') }}
 ```
 
 ## ⚙️ Configuration

--- a/prompts/README.md.jinja2
+++ b/prompts/README.md.jinja2
@@ -96,27 +96,21 @@ The CLI has global parameters and options that can be used to customize its beha
 {{ sh('python -m cli.cli --help') }}
 ```
 
-Then there are three sub-commands:
+#### Commands
 
-#### `pilot task PROMPT`
-
-Create a new task for PR Pilot using a prompt or prompt template.
+Hand over a task to PR Pilot.
 
 ```bash
 {{ sh('python -m cli.cli task --help') }}
 ```
 
-#### `pilot edit FILE PROMPT`
-
-Edit a local file using PR Pilot.
+Let PR Pilot edit a file for you.
 
 ```bash
 {{ sh('python -m cli.cli edit --help') }}
 ```
 
-#### `pilot plan PLAN`
-
-Run a step-by-step plan with PR Pilot.
+Let PR Pilot execute a step-by-step plan.
 
 ```bash
 {{ sh('python -m cli.cli plan --help') }}

--- a/prompts/test.yaml
+++ b/prompts/test.yaml
@@ -1,0 +1,12 @@
+name: Summarize a Github issue
+prompt: |
+  Summarize a Github issue in a single sentence. The summary should be concise and capture the main point of the issue.
+
+steps:
+  - name: Find the issue
+    prompt: Look at all open issues and give me a link to one of the issues.
+
+  - name: Summarize the issue
+    prompt: |
+      Read the issue and summarize it in a single sentence. The summary should be concise and capture the main point of the issue.
+      Write the summary here.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pr-pilot-cli',
-    version='1.8.1',
+    version='1.8.2',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
This PR refactors the CLI commands and updates the documentation to reflect these changes.

- Refactored CLI commands into sub-commands: `task`, `edit`, and `plan`.
- Updated the `Makefile` to use the new `task` sub-command.
- Modified the `README.md` to include examples and usage instructions for the new sub-commands.
- Updated the `setup.py` version to `1.8.2`.
- Added new command files: `edit.py`, `plan.py`, and `task.py`.
- Removed unused imports and cleaned up the `cli.py` file.
- Updated prompt templates to use the new `task` sub-command.