### PR TITLE
Fix sync behavior for new branches

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -1,4 +1,5 @@
 import click
+from rich.console import Console
 
 from cli.commands.edit import edit
 from cli.commands.plan import plan
@@ -52,4 +53,7 @@ main.add_command(plan)
 
 
 if __name__ == '__main__':
+    console = Console()
+    console.line()
     main()
+    console.line()

--- a/cli/commands/task.py
+++ b/cli/commands/task.py
@@ -43,12 +43,14 @@ def task(ctx, snap, cheap, code, file, direct, output, prompt):
     try:
         if ctx.obj['sync'] and not ctx.obj['branch']:
             # Get current branch from git
-            ctx.obj['branch'] = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
+            current_branch = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
+            if current_branch not in ['master', 'main']:
+                ctx.obj['branch'] = current_branch
 
         runner = TaskRunner(status_indicator)
-        runner.run_task(ctx.obj['wait'], ctx.obj['repo'], snap, None, ctx.obj['quiet'], cheap, code, file, direct, output, ctx.obj['model'], ctx.obj['debug'], prompt, branch=ctx.obj['branch'])
+        finished_task = runner.run_task(ctx.obj['wait'], ctx.obj['repo'], snap, None, ctx.obj['quiet'], cheap, code, file, direct, output, ctx.obj['model'], ctx.obj['debug'], prompt, branch=ctx.obj['branch'])
         if ctx.obj['sync']:
-            pull_branch_changes(status_indicator, console, ctx.obj['branch'], ctx.obj['debug'])
+            pull_branch_changes(status_indicator, console, finished_task.branch, ctx.obj['debug'])
 
     except Exception as e:
         status_indicator.fail()

--- a/cli/task_handler.py
+++ b/cli/task_handler.py
@@ -29,7 +29,7 @@ class TaskHandler:
         :return:
         """
 
-        self.status.update("Generating a task title ...")
+        self.status.update("Preparing task ...")
         self.status.start()
         try:
             start_time = time.time()

--- a/cli/util.py
+++ b/cli/util.py
@@ -43,8 +43,12 @@ def load_config():
 def pull_branch_changes(status_indicator, console, branch, debug=False):
     status_indicator.update(f"Pull latest changes from {branch}")
     try:
+        # Fetch origin and checkout branch
+        subprocess_params = dict(stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        subprocess.run(['git', 'fetch', 'origin'], **subprocess_params)
+        subprocess.run(['git', 'checkout', branch], **subprocess_params)
         # Capture output of git pull
-        result = subprocess.run(['git', 'pull', 'origin', branch], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(['git', 'pull', 'origin', branch], **subprocess_params)
         output = result.stdout
         error = result.stderr
         status_indicator.success()

--- a/issues.json
+++ b/issues.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 51,
+    "title": "🐛 Missing `cli/commands` directory",
+    "url": "https://github.com/PR-Pilot-AI/pr-pilot-cli/issues/51"
+  },
+  {
+    "id": 54,
+    "title": "🔍 Update issues.json with GitHub bug and handle Linear error",
+    "url": "https://github.com/PR-Pilot-AI/pr-pilot-cli/pull/54"
+  }
+]


### PR DESCRIPTION
When PR Pilot creates a new branch/PR, the `--sync` flag will automatically pull the new branch