### PR TITLE
🔧 Add more user configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 readme:
-	python -m cli.cli task --direct -f prompts/README.md.jinja2 -o README.md
+	python -m cli.cli --quiet task --direct -f prompts/README.md.jinja2 -o README.md
+	sed -i '' 's/python -m cli.cli/pilot/g' README.md
 pr-description:
 	python -m cli.cli task -f prompts/generate_pr_description.md.jinja2

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The CLI has global parameters and options that can be used to customize its beha
 
 
 ```bash
-Usage: pilot [OPTIONS] COMMAND [ARGS]...
+Usage: python -m cli.cli [OPTIONS] COMMAND [ARGS]...
 
   PR Pilot CLI - https://docs.pr-pilot.ai
 
@@ -117,7 +117,7 @@ Options:
   --quiet                   Disable all output on the terminal.
   -m, --model TEXT          GPT model to use.
   -b, --branch TEXT         Run the task on a specific branch.
-  --sync                    Run task on your current branch and pull PR
+  --sync / --no-sync        Run task on your current branch and pull PR
                             Pilot's changes when done.
   --debug                   Display debug information.
   --help                    Show this message and exit.
@@ -125,18 +125,18 @@ Options:
 Commands:
   edit  ✍️ Let PR Pilot edit a file for you.
   plan  📋 Let PR Pilot execute a plan for you.
-  task  🛠️Create a new task for PR Pilot.
+  task  🛠️ Create a new task for PR Pilot.
 
 ```
 
 #### Commands
 
-Work Delegation:
+Hand over a task to PR Pilot.
 
 ```bash
-Usage: pilot task [OPTIONS] [PROMPT]...
+Usage: python -m cli.cli task [OPTIONS] [PROMPT]
 
-  🛠️Create a new task for PR Pilot.
+  🛠️ Create a new task for PR Pilot.
 
   Examples:
 
@@ -162,10 +162,10 @@ Options:
 
 ```
 
-In-Place Editing:
+Let PR Pilot edit a file for you.
 
 ```bash
-Usage: pilot edit [OPTIONS] FILE_PATH PROMPT
+Usage: python -m cli.cli edit [OPTIONS] FILE_PATH PROMPT
 
   ✍️ Let PR Pilot edit a file for you.
 
@@ -185,10 +185,10 @@ Options:
 
 ```
 
-For more complex tasks:
+Let PR Pilot execute a step-by-step plan.
 
 ```bash
-Usage: pilot plan [OPTIONS] FILE_PATH
+Usage: python -m cli.cli plan [OPTIONS] FILE_PATH
 
   📋 Let PR Pilot execute a plan for you.
 
@@ -206,6 +206,12 @@ api_key: YOUR_API_KEY
 
 # Default Github repository if not running CLI in a repository directory
 default_repo: owner/repo
+
+# Enabled --sync by default
+auto_sync: true
+
+# Print status messages to the command line
+print_status: true
 ```
 
 ## 🤝 Contributing

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -5,6 +5,7 @@ from cli.commands.edit import edit
 from cli.commands.plan import plan
 from cli.commands.task import task
 from cli.constants import DEFAULT_MODEL
+from cli.util import load_config
 
 
 @click.group()
@@ -14,7 +15,7 @@ from cli.constants import DEFAULT_MODEL
 @click.option('--quiet', is_flag=True, default=False, help='Disable all output on the terminal.')
 @click.option('--model', '-m', help='GPT model to use.', default=DEFAULT_MODEL)
 @click.option('--branch', '-b', help='Run the task on a specific branch.', required=False, default=None)
-@click.option('--sync', is_flag=True, default=False, help='Run task on your current branch and pull PR Pilot\'s changes when done.')
+@click.option('--sync/--no-sync', is_flag=True, default=False, help='Run task on your current branch and pull PR Pilot\'s changes when done.')
 @click.option('--debug', is_flag=True, default=False, help='Display debug information.')
 @click.pass_context
 def main(ctx, wait, repo, spinner, quiet, model, branch, sync, debug):
@@ -36,14 +37,17 @@ def main(ctx, wait, repo, spinner, quiet, model, branch, sync, debug):
     - 🔄 Interact across services and tools:
       pilot task "Find all open Linear and Github issues labeled as 'bug' and send them to the #bugs Slack channel."
     """
+
+    user_config = load_config()
+
     ctx.ensure_object(dict)
     ctx.obj['wait'] = wait
     ctx.obj['repo'] = repo
     ctx.obj['spinner'] = spinner
-    ctx.obj['quiet'] = quiet
+    ctx.obj['quiet'] = user_config.get('quiet', quiet)
     ctx.obj['model'] = model
     ctx.obj['branch'] = branch
-    ctx.obj['sync'] = sync
+    ctx.obj['sync'] = user_config.get('auto_sync', sync)
     ctx.obj['debug'] = debug
 
 
@@ -53,7 +57,4 @@ main.add_command(plan)
 
 
 if __name__ == '__main__':
-    console = Console()
-    console.line()
     main()
-    console.line()

--- a/cli/commands/task.py
+++ b/cli/commands/task.py
@@ -38,8 +38,7 @@ def task(ctx, snap, cheap, code, file, direct, output, prompt):
       pilot task "Find all open Github issues labeled as 'bug' and send them to the #bugs Slack channel."
     """
     console = Console()
-    show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
-    status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
+    status_indicator = StatusIndicator(spinner=ctx.obj['spinner'], messages=not ctx.obj['quiet'], console=console)
 
     try:
         if ctx.obj['sync'] and not ctx.obj['branch']:
@@ -67,7 +66,8 @@ def task(ctx, snap, cheap, code, file, direct, output, prompt):
         runner = TaskRunner(status_indicator)
         finished_task = runner.run_task(task_params)
         if ctx.obj['sync']:
-            pull_branch_changes(status_indicator, console, finished_task.branch, ctx.obj['debug'])
+            branch = finished_task.branch if finished_task else ctx.obj['branch']
+            pull_branch_changes(status_indicator, console, branch, ctx.obj['debug'])
 
     except Exception as e:
         status_indicator.fail()

--- a/cli/status_indicator.py
+++ b/cli/status_indicator.py
@@ -13,11 +13,9 @@ class StatusIndicator:
     def update(self, text):
         if self.visible:
             self.spinner.text = text
-        elif self.messages:
-            self.console.print(f"[bold]>[/bold] {text}")
 
     def success(self):
-        if self.visible:
+        if self.visible and self.messages:
             self.spinner.ok("✅ ")
             self.spinner.start()
 

--- a/cli/task_handler.py
+++ b/cli/task_handler.py
@@ -68,7 +68,7 @@ class TaskHandler:
             else:
                 self.status.success()
                 self.status.stop()
-                if not quiet:
+                if not quiet and result:
                     self.console.line()
                     self.console.print(Markdown(result))
                     self.console.line()

--- a/prompts/README.md.jinja2
+++ b/prompts/README.md.jinja2
@@ -125,6 +125,12 @@ api_key: YOUR_API_KEY
 
 # Default Github repository if not running CLI in a repository directory
 default_repo: owner/repo
+
+# Enabled --sync by default
+auto_sync: true
+
+# Print status messages to the command line
+print_status: true
 ```
 
 ## 🤝 Contributing

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pr-pilot-cli',
-    version='1.8.5',
+    version='1.8.6',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
This PR adds more user configurations and updates the CLI behavior.

- Update `Makefile` to use `--quiet` flag and replace `python -m cli.cli` with `pilot` in `README.md`.
- Modify `README.md` to reflect changes in CLI usage and options.
- Add `load_config` to `cli.py` to load user configurations.
- Update `main` function in `cli.py` to use user configurations for `quiet` and `sync` options.
- Adjust `task` command in `task.py` to use status indicator based on user configurations.
- Refactor `status_indicator.py` to handle message visibility.
- Modify `wait_for_result` in `task_handler.py` to print results based on `quiet` option.
- Update `README.md.jinja2` to include new configuration options.