### PR TITLE
✍️ Allow multiline prompt input in edit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Options:
   --wait / --no-wait        Wait for PR Pilot to finish the task.
   --repo TEXT               Github repository in the format owner/repo.
   --spinner / --no-spinner  Display a loading indicator.
-  --quiet                   Disable all output on the terminal.
+  --quiet / --chatty        Disable all status messages.
   -m, --model TEXT          GPT model to use.
   -b, --branch TEXT         Run the task on a specific branch.
   --sync / --no-sync        Run task on your current branch and pull PR
@@ -165,7 +165,7 @@ Options:
 Let PR Pilot edit a file for you.
 
 ```bash
-Usage: pilot edit [OPTIONS] FILE_PATH PROMPT
+Usage: pilot edit [OPTIONS] FILE_PATH [PROMPT]
 
   ✍️ Let PR Pilot edit a file for you.
 
@@ -181,6 +181,7 @@ Usage: pilot edit [OPTIONS] FILE_PATH PROMPT
     pilot edit "I left placeholder comments in the file. Please replace them with the actual code."
 
 Options:
+  --snap  📸 Add a screenshot to your prompt.
   --help  Show this message and exit.
 
 ```

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -12,7 +12,7 @@ from cli.util import load_config
 @click.option('--wait/--no-wait', is_flag=True, default=True, help='Wait for PR Pilot to finish the task.')
 @click.option('--repo', help='Github repository in the format owner/repo.', required=False)
 @click.option('--spinner/--no-spinner', is_flag=True, default=True, help='Display a loading indicator.')
-@click.option('--quiet', is_flag=True, default=False, help='Disable all status messages.')
+@click.option('--quiet/--chatty', is_flag=True, default=False, help='Disable all status messages.')
 @click.option('--model', '-m', help='GPT model to use.', default=DEFAULT_MODEL)
 @click.option('--branch', '-b', help='Run the task on a specific branch.', required=False, default=None)
 @click.option('--sync/--no-sync', is_flag=True, default=False, help='Run task on your current branch and pull PR Pilot\'s changes when done.')

--- a/cli/commands/edit.py
+++ b/cli/commands/edit.py
@@ -34,8 +34,7 @@ def edit(ctx, snap, file_path, prompt):
 
     """
     console = Console()
-    show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
-    status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
+    status_indicator = StatusIndicator(spinner=ctx.obj['spinner'], messages=not ctx.obj['quiet'], console=console)
 
     if not prompt:
         prompt = click.edit("", extension=".md")

--- a/cli/commands/edit.py
+++ b/cli/commands/edit.py
@@ -4,18 +4,18 @@ from pathlib import Path
 import click
 from rich.console import Console
 
-from cli.constants import CODE_PRIMER
+from cli.models import TaskParameters
 from cli.status_indicator import StatusIndicator
 from cli.task_runner import TaskRunner
 from cli.util import pull_branch_changes
-from cli.models import TaskParameters
 
 
 @click.command()
+@click.option('--snap', is_flag=True, help='📸 Add a screenshot to your prompt.')
 @click.argument('file_path', type=click.Path(exists=True))
-@click.argument('prompt')
+@click.argument('prompt', required=False, default=None, type=str)
 @click.pass_context
-def edit(ctx, file_path, prompt):
+def edit(ctx, snap, file_path, prompt):
     """✍️ Let PR Pilot edit a file for you.
 
     Examples:
@@ -37,6 +37,9 @@ def edit(ctx, file_path, prompt):
     show_spinner = ctx.obj['spinner'] and not ctx.obj['quiet']
     status_indicator = StatusIndicator(spinner=show_spinner, messages=not ctx.obj['quiet'], console=console)
 
+    if not prompt:
+        prompt = click.edit("", extension=".md")
+
     file_content = Path(file_path).read_text()
     user_prompt = prompt
     prompt = f"I have the following file content:\n\n---\n{file_content}\n---\n\n"
@@ -50,6 +53,7 @@ def edit(ctx, file_path, prompt):
                 ctx.obj['branch'] = current_branch
 
         task_params = TaskParameters(
+            snap=snap,
             wait=ctx.obj['wait'],
             repo=ctx.obj['repo'],
             quiet=ctx.obj['quiet'],

--- a/cli/models.py
+++ b/cli/models.py
@@ -3,6 +3,9 @@ from typing import Optional
 
 
 class TaskParameters(BaseModel):
+    """
+    Model representing the parameters for a task.
+    """
     wait: bool = Field(default=False, description="Wait for the task to complete")
     repo: Optional[str] = Field(default=None, description="Repository to run the task on")
     snap: bool = Field(default=False, description="Take a screenshot")

--- a/cli/models.py
+++ b/cli/models.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import Optional
 
+
 class TaskParameters(BaseModel):
     wait: bool = Field(default=False, description="Wait for the task to complete")
     repo: Optional[str] = Field(default=None, description="Repository to run the task on")

--- a/cli/task_handler.py
+++ b/cli/task_handler.py
@@ -73,8 +73,7 @@ class TaskHandler:
                     self.console.line()
                     # If quiet mode is enabled, we still want to show the PR URL
                     if quiet and new_pr_url:
-                        reference_emojis = "🔗" if self.task_runs_on_pr else "🔗🆕"
-                        result += f"\n\n[🆕 **PR #{self.task.pr_number}**]({new_pr_url})"
+                        result += f"\n\n🆕 [**PR #{self.task.pr_number}**]({new_pr_url})"
                     self.console.print(Markdown(result))
                     self.console.line()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pr-pilot-cli',
-    version='1.8.8',
+    version='1.8.9',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
This PR allows for multiline prompt input in the edit command, improving user experience and flexibility.

- Added support for multiline prompt input in the `edit` command.
- Introduced `--snap` option to add a screenshot to the prompt.
- Fixed spinner behavior in the `edit` command.
- Updated `TaskParameters` model to include `snap` attribute.
- Adjusted `setup.py` version to `1.8.9`.
- Minor code refactoring and cleanup.