### PR TITLE
🔧 Add upgrade command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,33 @@ The CLI has global parameters and options that can be used to customize its beha
 
 
 ```bash
+Usage: pilot [OPTIONS] COMMAND [ARGS]...
+
+  PR Pilot CLI - https://docs.pr-pilot.ai
+
+  Delegate routine work to AI with confidence and predictability.
+
+Options:
+  --wait / --no-wait        Wait for PR Pilot to finish the task.
+  --repo TEXT               Github repository in the format owner/repo.
+  --spinner / --no-spinner  Display a loading indicator.
+  --verbose                 Display status messages
+  -m, --model TEXT          GPT model to use.
+  -b, --branch TEXT         Run the task on a specific branch.
+  --sync / --no-sync        Run task on your current branch and pull PR Pilots
+                            changes when done.
+  --debug                   Display debug information.
+  --help                    Show this message and exit.
+
+Commands:
+  config   🔧 Customize PR Pilots behavior.
+  edit     ✍️ Let PR Pilot edit a file for you.
+  grab     🤲 Grab commands, prompts and plans from other repositories.
+  history  📜 Access recent tasks.
+  plan     📋 Let PR Pilot execute a plan for you.
+  run      🚀 Run a saved command.
+  task     ➕ Create a new task for PR Pilot.
+  upgrade  ⬆️ Upgrade pr-pilot-cli to the latest version.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -172,32 +172,6 @@ The CLI has global parameters and options that can be used to customize its beha
 
 
 ```bash
-Usage: pilot [OPTIONS] COMMAND [ARGS]...
-
-  PR Pilot CLI - https://docs.pr-pilot.ai
-
-  Delegate routine work to AI with confidence and predictability.
-
-Options:
-  --wait / --no-wait        Wait for PR Pilot to finish the task.
-  --repo TEXT               Github repository in the format owner/repo.
-  --spinner / --no-spinner  Display a loading indicator.
-  --verbose                 Display status messages
-  -m, --model TEXT          GPT model to use.
-  -b, --branch TEXT         Run the task on a specific branch.
-  --sync / --no-sync        Run task on your current branch and pull PR Pilots
-                            changes when done.
-  --debug                   Display debug information.
-  --help                    Show this message and exit.
-
-Commands:
-  config   🔧 Customize PR Pilots behavior.
-  edit     ✍️ Let PR Pilot edit a file for you.
-  grab     🤲 Grab commands, prompts and plans from other repositories.
-  history  📜 Access recent tasks.
-  plan     📋 Let PR Pilot execute a plan for you.
-  run      🚀 Run a saved command.
-  task     ➕ Create a new task for PR Pilot.
 
 ```
 

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -89,7 +89,7 @@ main.add_command(config)
 main.add_command(upgrade)
 
 run_command_help = """
-\ud83d\ude80 Run a saved command.
+🚀 Run a saved command.
 
 Create new commands by using the --save-command flag when running a task.
 """

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -9,6 +9,7 @@ from cli.commands.plan import plan
 from cli.commands.run import RunCommand
 from cli.commands.task import task
 from cli.commands.config import config
+from cli.commands.upgrade import upgrade
 from cli.constants import DEFAULT_MODEL, CONFIG_API_KEY
 from cli.util import load_config
 
@@ -85,9 +86,10 @@ main.add_command(plan)
 main.add_command(grab)
 main.add_command(history)
 main.add_command(config)
+main.add_command(upgrade)
 
 run_command_help = """
-🚀 Run a saved command.
+\ud83d\ude80 Run a saved command.
 
 Create new commands by using the --save-command flag when running a task.
 """

--- a/cli/commands/task.py
+++ b/cli/commands/task.py
@@ -122,10 +122,5 @@ def task(ctx, snap, cheap, code, file, direct, output, save_command, prompt):
             if branch:
                 pull_branch_changes(status_indicator, console, branch, ctx.obj["debug"])
 
-    except Exception as e:
-        status_indicator.fail()
-        if ctx.obj["debug"]:
-            raise
-        console.print(f"[bold red]An error occurred:[/bold red] {type(e)} {str(e)}")
     finally:
         status_indicator.stop()

--- a/cli/commands/upgrade.py
+++ b/cli/commands/upgrade.py
@@ -4,15 +4,21 @@ import sys
 import click
 from rich.prompt import Confirm
 
+
 @click.command()
 def upgrade():
     """Upgrade pr-pilot-cli to the latest version."""
-    if Confirm.ask("Do you want to upgrade pr-pilot-cli?"):
-        if is_installed_via_homebrew():
+    if is_installed_via_homebrew():
+        if Confirm.ask(
+            "Found homebrew installation. Upgrade the [code]pr-pilot-cli[/code] package?"
+        ):
             subprocess.run(["brew", "update"], check=True)
             subprocess.run(["brew", "upgrade", "pr-pilot-cli"], check=True)
-        else:
-            subprocess.run([sys.executable, "-m", "pip", "install", "--upgrade", "pr-pilot-cli"], check=True)
+    else:
+        if Confirm.ask("Upgrade the [code]pr-pilot-cli[/code] package with pip?"):
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--upgrade", "pr-pilot-cli"], check=True
+            )
 
 
 def is_installed_via_homebrew() -> bool:

--- a/cli/commands/upgrade.py
+++ b/cli/commands/upgrade.py
@@ -1,0 +1,21 @@
+import subprocess
+import sys
+
+import click
+from rich.prompt import Confirm
+
+@click.command()
+def upgrade():
+    """Upgrade pr-pilot-cli to the latest version."""
+    if Confirm.ask("Do you want to upgrade pr-pilot-cli?"):
+        if is_installed_via_homebrew():
+            subprocess.run(["brew", "update"], check=True)
+            subprocess.run(["brew", "upgrade", "pr-pilot-cli"], check=True)
+        else:
+            subprocess.run([sys.executable, "-m", "pip", "install", "--upgrade", "pr-pilot-cli"], check=True)
+
+
+def is_installed_via_homebrew() -> bool:
+    """Check if pr-pilot-cli is installed via Homebrew."""
+    result = subprocess.run(["brew", "list", "pr-pilot-cli"], capture_output=True)
+    return result.returncode == 0

--- a/cli/commands/upgrade.py
+++ b/cli/commands/upgrade.py
@@ -7,7 +7,7 @@ from rich.prompt import Confirm
 
 @click.command()
 def upgrade():
-    """Upgrade pr-pilot-cli to the latest version."""
+    """⬆️ Upgrade pr-pilot-cli to the latest version."""
     if is_installed_via_homebrew():
         if Confirm.ask(
             "Found homebrew installation. Upgrade the [code]pr-pilot-cli[/code] package?"

--- a/cli/task_handler.py
+++ b/cli/task_handler.py
@@ -88,7 +88,5 @@ class TaskHandler:
                 if print_result:
                     self.console.print(Panel(Markdown(result), title="Result", expand=False))
 
-        except Exception as e:
-            self.status.update(f"Error: {e}")
-            self.status.fail()
-            raise click.ClickException(f"An error occurred: {e}")
+        finally:
+            self.status.stop()

--- a/cli/util.py
+++ b/cli/util.py
@@ -28,51 +28,52 @@ def clean_code_block_with_language_specifier(response):
     return clean_response
 
 
+def collect_user_preferences():
+    console = Console()
+    api_key_url = "https://app.pr-pilot.ai/dashboard/api-keys/"
+    console.print(f"Please create an API key at {api_key_url}.")
+    api_key = click.prompt("PR Pilot API key")
+
+    console.line()
+    console.print(
+        "[green]Since it's the first time you're using PR Pilot, "
+        "let's set some default values.[/green]"
+    )
+    console.line()
+    auto_sync = click.confirm(
+        "When a new PR/branch is created, do you want it checked out automatically?"
+    )
+    verbose = click.confirm("Do you want to see detailed status messages?")
+    console.line()
+    with open(CONFIG_LOCATION, "w") as f:
+        f.write(
+            yaml.dump(
+                {
+                    CONFIG_API_KEY: api_key,
+                    "auto_sync": auto_sync,
+                    "verbose": verbose,
+                }
+            )
+        )
+    console.print(f"Configuration saved in [code]{CONFIG_LOCATION}[/code]")
+
+
 def load_config():
     """Load the configuration from the default location. If it doesn't exist,
     ask user to enter API key and save config."""
     console = Console()
-    user_config = {}
+    if not os.path.exists(CONFIG_LOCATION) and not os.getenv("PR_PILOT_API_KEY"):
+        collect_user_preferences()
 
-    if not os.path.exists(CONFIG_LOCATION):
-
-        api_key_url = "https://app.pr-pilot.ai/dashboard/api-keys/"
-        console.print(f"Configuration file not found. Please create an API key at {api_key_url}.")
-        api_key = click.prompt("PR Pilot API key")
-        user_config[CONFIG_API_KEY] = api_key
+    if not os.path.exists(CONFIG_LOCATION) and os.getenv("PR_PILOT_API_KEY"):
+        console.print(
+            "[bold yellow]Using API key from environment variable PR_PILOT_API_KEY[/bold yellow]"
+        )
+        config = {CONFIG_API_KEY: os.getenv("PR_PILOT_API_KEY")}
     else:
         with open(CONFIG_LOCATION) as f:
-            user_config = yaml.safe_load(f)
+            config = yaml.safe_load(f)
 
-    if os.getenv("PR_PILOT_API_KEY"):
-        console.print("Using API key from environment variable.")
-        api_key = os.getenv("PR_PILOT_API_KEY")
-        user_config[CONFIG_API_KEY] = api_key
-
-        console.line()
-        console.print(
-            "[green]Since it's the first time you're using PR Pilot, "
-            "let's set some default values.[/green]"
-        )
-        console.line()
-        auto_sync = click.confirm(
-            "When a new PR/branch is created, do you want it checked out automatically?"
-        )
-        verbose = click.confirm("Do you want to see detailed status messages?")
-        console.line()
-        with open(CONFIG_LOCATION, "w") as f:
-            f.write(
-                yaml.dump(
-                    {
-                        CONFIG_API_KEY: api_key,
-                        "auto_sync": auto_sync,
-                        "verbose": verbose,
-                    }
-                )
-            )
-        console.print(f"Configuration saved in [code]{CONFIG_LOCATION}[/code]")
-    with open(CONFIG_LOCATION) as f:
-        config = yaml.safe_load(f)
     return config
 
 

--- a/cli/util.py
+++ b/cli/util.py
@@ -31,17 +31,24 @@ def clean_code_block_with_language_specifier(response):
 def load_config():
     """Load the configuration from the default location. If it doesn't exist,
     ask user to enter API key and save config."""
+    console = Console()
+    user_config = {}
+
     if not os.path.exists(CONFIG_LOCATION):
-        console = Console()
-        if os.getenv("PR_PILOT_API_KEY"):
-            console.print("Using API key from environment variable.")
-            api_key = os.getenv("PR_PILOT_API_KEY")
-        else:
-            api_key_url = "https://app.pr-pilot.ai/dashboard/api-keys/"
-            console.print(
-                f"Configuration file not found. Please create an API key at {api_key_url}."
-            )
-            api_key = click.prompt("PR Pilot API key")
+
+        api_key_url = "https://app.pr-pilot.ai/dashboard/api-keys/"
+        console.print(f"Configuration file not found. Please create an API key at {api_key_url}.")
+        api_key = click.prompt("PR Pilot API key")
+        user_config[CONFIG_API_KEY] = api_key
+    else:
+        with open(CONFIG_LOCATION) as f:
+            user_config = yaml.safe_load(f)
+
+    if os.getenv("PR_PILOT_API_KEY"):
+        console.print("Using API key from environment variable.")
+        api_key = os.getenv("PR_PILOT_API_KEY")
+        user_config[CONFIG_API_KEY] = api_key
+
         console.line()
         console.print(
             "[green]Since it's the first time you're using PR Pilot, "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,12 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def mock_default_config_location(tmp_path):
+    with patch("cli.util.CONFIG_LOCATION", tmp_path / "config.yaml"):
+        yield tmp_path / "config.yaml"
+
+
+@pytest.fixture(autouse=True)
 def mock_create_task():
     with patch("cli.task_runner.create_task") as mock:
         yield mock

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,19 +1,19 @@
 import os
-import subprocess
+from datetime import timezone, datetime
+from unittest.mock import patch, mock_open
+
+import humanize
 import pytest
 import yaml
-from unittest.mock import patch, mock_open
-from click.testing import CliRunner
 from pr_pilot import Task
+from rich.markdown import Markdown
+
+from cli.constants import CONFIG_API_KEY
 from cli.util import (
     clean_code_block_with_language_specifier,
-    collect_user_preferences,
     load_config,
-    pull_branch_changes,
     TaskFormatter,
-    PaddedConsole
 )
-from cli.constants import CONFIG_LOCATION, CONFIG_API_KEY
 
 
 @pytest.fixture
@@ -47,56 +47,15 @@ def foo():
     assert clean_code_block_with_language_specifier(response) == expected
 
 
-def test_collect_user_preferences(mock_console, mock_click_prompt, mock_click_confirm):
-    mock_click_prompt.side_effect = ["test_api_key"]
-    mock_click_confirm.side_effect = [True, False]
-
-    with patch("builtins.open", mock_open()) as mocked_file:
-        collect_user_preferences()
-        mocked_file.assert_called_once_with(CONFIG_LOCATION, "w")
-        handle = mocked_file()
-        written_data = yaml.safe_load(handle.write.call_args[0][0])
-        assert written_data == {
-            CONFIG_API_KEY: "test_api_key",
-            "auto_sync": True,
-            "verbose": False,
-        }
-
-
 def test_load_config(mock_console):
     config_data = {CONFIG_API_KEY: "test_api_key"}
 
+    # Make sure PR_PILOT_API_KEY env var has priority over config file
     with patch.dict(os.environ, {"PR_PILOT_API_KEY": "test_api_key_env"}):
-        with patch("builtins.open", mock_open(read_data=yaml.dump(config_data))):
-            config = load_config()
-            assert config == config_data
-
-    with patch("os.path.exists", return_value=False):
-        with patch("builtins.open", mock_open(read_data=yaml.dump(config_data))):
-            config = load_config()
-            assert config == {CONFIG_API_KEY: "test_api_key_env"}
-
-
-@patch("subprocess.run")
-def test_pull_branch_changes(mock_subprocess_run, mock_console):
-    mock_status_indicator = mock_console.status_indicator
-    mock_status_indicator.start = patch("cli.util.StatusIndicator.start").start()
-    mock_status_indicator.update = patch("cli.util.StatusIndicator.update").start()
-    mock_status_indicator.success = patch("cli.util.StatusIndicator.success").start()
-    mock_status_indicator.fail = patch("cli.util.StatusIndicator.fail").start()
-    mock_status_indicator.stop = patch("cli.util.StatusIndicator.stop").start()
-
-    mock_subprocess_run.return_value = subprocess.CompletedProcess(
-        args=["git", "pull", "origin", "branch"], returncode=0, stdout="output", stderr=""
-    )
-
-    pull_branch_changes(mock_status_indicator, mock_console, "branch", debug=True)
-
-    mock_status_indicator.start.assert_called_once()
-    mock_status_indicator.update.assert_called_once_with("Pull latest changes from branch")
-    mock_status_indicator.success.assert_called_once()
-    mock_status_indicator.stop.assert_called_once()
-    mock_console.print.assert_called_with("output")
+        with patch("os.path.exists", return_value=False):
+            with patch("builtins.open", mock_open(read_data=yaml.dump(config_data))):
+                config = load_config()
+                assert config == {CONFIG_API_KEY: "test_api_key_env"}
 
 
 @pytest.fixture
@@ -104,25 +63,26 @@ def sample_task():
     return Task(
         id="1",
         github_project="test_project",
-        created=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        github_user="test_user",
+        created=datetime.now(timezone.utc),
         pr_number=1,
         status="running",
         title="Test Task",
-        branch="test-branch"
+        branch="test-branch",
     )
 
 
 def test_task_formatter(sample_task):
     formatter = TaskFormatter(sample_task)
-    assert formatter.format_github_project() == "[link=https://github.com/test_project]test_project[/link]"
+    assert (
+        formatter.format_github_project()
+        == "[link=https://github.com/test_project]test_project[/link]"
+    )
     assert formatter.format_created_at() == humanize.naturaltime(sample_task.created)
     assert formatter.format_pr_link() == "[link=https://github.com/test_project/pull/1]#1[/link]"
     assert formatter.format_status() == "[bold yellow]running[/bold yellow]"
-    assert formatter.format_title() == "[link=https://app.pr-pilot.ai/dashboard/tasks/1/]Test Task[/link]"
-    assert formatter.format_branch() == Markdown("`test-branch`")
-
-
-def test_padded_console(mock_console):
-    padded_console = PaddedConsole(padding=(2, 2))
-    padded_console.print("Test Content")
-    mock_console.print.assert_called_once()
+    assert (
+        formatter.format_title()
+        == "[link=https://app.pr-pilot.ai/dashboard/tasks/1/]Test Task[/link]"
+    )
+    assert formatter.format_branch().markup == Markdown("`test-branch`").markup

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,128 @@
+import os
+import subprocess
+import pytest
+import yaml
+from unittest.mock import patch, mock_open
+from click.testing import CliRunner
+from pr_pilot import Task
+from cli.util import (
+    clean_code_block_with_language_specifier,
+    collect_user_preferences,
+    load_config,
+    pull_branch_changes,
+    TaskFormatter,
+    PaddedConsole
+)
+from cli.constants import CONFIG_LOCATION, CONFIG_API_KEY
+
+
+@pytest.fixture
+@patch("cli.util.Console")
+def mock_console(mock_console_class):
+    return mock_console_class.return_value
+
+
+@pytest.fixture
+@patch("cli.util.click.prompt")
+def mock_click_prompt(mock_prompt):
+    return mock_prompt
+
+
+@pytest.fixture
+@patch("cli.util.click.confirm")
+def mock_click_confirm(mock_confirm):
+    return mock_confirm
+
+
+def test_clean_code_block_with_language_specifier():
+    response = """```python
+def foo():
+    pass
+```"""
+    expected = "def foo():\n    pass"
+    assert clean_code_block_with_language_specifier(response) == expected
+
+    response = "def foo():\n    pass"
+    expected = "def foo():\n    pass"
+    assert clean_code_block_with_language_specifier(response) == expected
+
+
+def test_collect_user_preferences(mock_console, mock_click_prompt, mock_click_confirm):
+    mock_click_prompt.side_effect = ["test_api_key"]
+    mock_click_confirm.side_effect = [True, False]
+
+    with patch("builtins.open", mock_open()) as mocked_file:
+        collect_user_preferences()
+        mocked_file.assert_called_once_with(CONFIG_LOCATION, "w")
+        handle = mocked_file()
+        written_data = yaml.safe_load(handle.write.call_args[0][0])
+        assert written_data == {
+            CONFIG_API_KEY: "test_api_key",
+            "auto_sync": True,
+            "verbose": False,
+        }
+
+
+def test_load_config(mock_console):
+    config_data = {CONFIG_API_KEY: "test_api_key"}
+
+    with patch.dict(os.environ, {"PR_PILOT_API_KEY": "test_api_key_env"}):
+        with patch("builtins.open", mock_open(read_data=yaml.dump(config_data))):
+            config = load_config()
+            assert config == config_data
+
+    with patch("os.path.exists", return_value=False):
+        with patch("builtins.open", mock_open(read_data=yaml.dump(config_data))):
+            config = load_config()
+            assert config == {CONFIG_API_KEY: "test_api_key_env"}
+
+
+@patch("subprocess.run")
+def test_pull_branch_changes(mock_subprocess_run, mock_console):
+    mock_status_indicator = mock_console.status_indicator
+    mock_status_indicator.start = patch("cli.util.StatusIndicator.start").start()
+    mock_status_indicator.update = patch("cli.util.StatusIndicator.update").start()
+    mock_status_indicator.success = patch("cli.util.StatusIndicator.success").start()
+    mock_status_indicator.fail = patch("cli.util.StatusIndicator.fail").start()
+    mock_status_indicator.stop = patch("cli.util.StatusIndicator.stop").start()
+
+    mock_subprocess_run.return_value = subprocess.CompletedProcess(
+        args=["git", "pull", "origin", "branch"], returncode=0, stdout="output", stderr=""
+    )
+
+    pull_branch_changes(mock_status_indicator, mock_console, "branch", debug=True)
+
+    mock_status_indicator.start.assert_called_once()
+    mock_status_indicator.update.assert_called_once_with("Pull latest changes from branch")
+    mock_status_indicator.success.assert_called_once()
+    mock_status_indicator.stop.assert_called_once()
+    mock_console.print.assert_called_with("output")
+
+
+@pytest.fixture
+def sample_task():
+    return Task(
+        id="1",
+        github_project="test_project",
+        created=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        pr_number=1,
+        status="running",
+        title="Test Task",
+        branch="test-branch"
+    )
+
+
+def test_task_formatter(sample_task):
+    formatter = TaskFormatter(sample_task)
+    assert formatter.format_github_project() == "[link=https://github.com/test_project]test_project[/link]"
+    assert formatter.format_created_at() == humanize.naturaltime(sample_task.created)
+    assert formatter.format_pr_link() == "[link=https://github.com/test_project/pull/1]#1[/link]"
+    assert formatter.format_status() == "[bold yellow]running[/bold yellow]"
+    assert formatter.format_title() == "[link=https://app.pr-pilot.ai/dashboard/tasks/1/]Test Task[/link]"
+    assert formatter.format_branch() == Markdown("`test-branch`")
+
+
+def test_padded_console(mock_console):
+    padded_console = PaddedConsole(padding=(2, 2))
+    padded_console.print("Test Content")
+    mock_console.print.assert_called_once()


### PR DESCRIPTION
This PR introduces an upgrade command to the CLI, allowing users to easily update the pr-pilot-cli package via Homebrew or pip.

**Summary of changes:**

- **New Command:**
  - Add [upgrade](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/upgrade-command/cli/commands/upgrade.py) command to upgrade pr-pilot-cli via Homebrew or pip.
  - Register the upgrade command in the main CLI entry point ([cli/cli.py](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/upgrade-command/cli/cli.py)).

- **Error Handling:**
  - Remove duplicate error messages in [task](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/upgrade-command/cli/commands/task.py) and [task_handler](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/upgrade-command/cli/task_handler.py).

- **Configuration:**
  - Refactor configuration loader to separate user preference collection ([cli/util.py](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/upgrade-command/cli/util.py)).
  - Mock config location in tests ([tests/conftest.py](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/upgrade-command/tests/conftest.py)).

- **Testing:**
  - Add unit tests for [cli/util.py](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/upgrade-command/tests/test_util.py).
  - Adjust confirmation messages and add unit tests.
