### PR TITLE
🧪 Add test for sync option

### DIFF
--- a/cli/commands/task.py
+++ b/cli/commands/task.py
@@ -1,15 +1,14 @@
-import os
 import click
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.padding import Padding
 
+from cli.command_index import CommandIndex, PilotCommand
 from cli.constants import CHEAP_MODEL
+from cli.models import TaskParameters
 from cli.status_indicator import StatusIndicator
 from cli.task_runner import TaskRunner
-from cli.models import TaskParameters
-from cli.util import pull_branch_changes
-from cli.command_index import CommandIndex, PilotCommand
+from cli.util import pull_branch_changes, get_current_branch
 
 
 @click.command()
@@ -69,7 +68,7 @@ def task(ctx, snap, cheap, code, file, direct, output, save_command, prompt):
     try:
         if ctx.obj["sync"]:
             # Get current branch from git
-            current_branch = os.popen("git rev-parse --abbrev-ref HEAD").read().strip()
+            current_branch = get_current_branch()
             if current_branch not in ["master", "main"]:
                 ctx.obj["branch"] = current_branch
 

--- a/cli/prompt_template.py
+++ b/cli/prompt_template.py
@@ -17,11 +17,15 @@ def sh(shell_command, status):
     try:
         if isinstance(shell_command, str):
             shell_command = shell_command.split()
-        process = subprocess.Popen(shell_command, stdout=subprocess.PIPE)
-        output, error = process.communicate()
+        subprocess_params = dict(stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(shell_command, **subprocess_params)
+        output = result.stdout
+        if result.stderr:
+            status.fail()
+            raise click.ClickException(f"Error running shell command: {result.stderr}")
         status.success(start_again=False)
         status.stop()
-        return output.decode("utf-8")
+        return output
     except Exception as e:
         click.echo(str(e))
         status.fail()

--- a/cli/status_indicator.py
+++ b/cli/status_indicator.py
@@ -19,7 +19,7 @@ class StatusIndicator:
 
     def success(self, start_again=False):
         if self.visible and self.messages:
-            self.spinner.ok("✔️")
+            self.spinner.ok("✔")
             if start_again:
                 self.spinner.start()
             self.spinner.start()

--- a/cli/task_runner.py
+++ b/cli/task_runner.py
@@ -100,7 +100,7 @@ class TaskRunner:
         if not params.verbose:
             # Status messages are only visible in verbose mode, so let's print the new task ID
             message = (
-                f"✔️ [bold][green]Task created[/green]: "
+                f"✔ [bold][green]Task created[/green]: "
                 f"[link=https://app.pr-pilot.ai/dashboard/tasks/{task.id}/]{task.id}[/link][/bold]"
                 f"{branch_str}{pr_link}"
             )

--- a/cli/util.py
+++ b/cli/util.py
@@ -154,3 +154,7 @@ class PaddedConsole:
     def print(self, content):
         padded_content = Padding(content, self.padding)
         self.console.print(padded_content)
+
+
+def get_current_branch():
+    return os.popen("git rev-parse --abbrev-ref HEAD").read().strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pr-pilot-cli"
-version = "1.11.6"
+version = "1.11.7"
 description = "CLI for PR Pilot, a text-to-task automation platform for Github."
 authors = ["Marco Lamina <marco@pr-pilot.ai>"]
 license = "GPL-3.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,3 +63,20 @@ def test_save_command_param_does_not_run_task(
     result = runner.invoke(main, ["task", "--save-command", "test-prompt"])
     mock_create_task.assert_not_called()
     assert result.exit_code == 0
+
+
+@patch("cli.commands.task.get_current_branch")
+@patch("cli.commands.task.pull_branch_changes")
+def test_sync_option_syncs_correctly(
+    mock_pull_branch_changes,
+    mock_get_current_branch,
+    runner,
+    mock_create_task,
+):
+    """The --sync option should set the branch to the current branch"""
+    mock_get_current_branch.return_value = "test-value"
+    result = runner.invoke(main, ["--wait", "--sync", "task", "test-prompt"])
+    mock_create_task.assert_called_once()
+    mock_pull_branch_changes.assert_called_once()
+    assert mock_create_task.call_args[1]["branch"] == "test-value"
+    assert result.exit_code == 0

--- a/tests/test_command_grabbing.py
+++ b/tests/test_command_grabbing.py
@@ -43,7 +43,7 @@ def test_prompt_user_for_commands(mock_command_index):
     ]
     with patch("inquirer.prompt") as mock_prompt:
         mock_prompt.return_value = {"commands": ["cmd1"]}
-        answers = prompt_user_for_commands(mock_command_index)
+        answers = prompt_user_for_commands(mock_command_index, MagicMock())
         assert answers == {"commands": ["cmd1"]}
         mock_prompt.assert_called_once()
 


### PR DESCRIPTION
This PR adds a test for the sync option and fixes some formatting issues.

**Changes**
- Add a test for the sync option in [`tests/test_cli.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/fix-syncing/tests/test_cli.py)
- Fix formatting issues in various files

**Formatting Fixes**
- Replace `✔️` with `✔` in status messages in [`cli/status_indicator.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/fix-syncing/cli/status_indicator.py) and [`cli/task_runner.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/fix-syncing/cli/task_runner.py)
- Update subprocess handling in [`cli/prompt_template.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/fix-syncing/cli/prompt_template.py)

**Code Refactoring**
- Move `get_current_branch` function to [`cli/util.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/fix-syncing/cli/util.py) and use it in [`cli/commands/task.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/fix-syncing/cli/commands/task.py)
- Update `prompt_user_for_commands` call in [`tests/test_command_grabbing.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/fix-syncing/tests/test_command_grabbing.py) to include a mock object

**Testing**
- Ensure the `--sync` option sets the branch to the current branch in [`tests/test_cli.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/fix-syncing/tests/test_cli.py)