### PR TITLE
✨ Add select command for prompt templates

### DIFF
--- a/.pilot-commands.yaml
+++ b/.pilot-commands.yaml
@@ -56,3 +56,17 @@ commands:
     sync: true
     verbose: true
     wait: true
+- description: Ask a question about our K8s resources
+  name: k8s-question
+  params:
+    cheap: false
+    code: false
+    debug: false
+    direct: false
+    file: prompts/k8s-question.jinja2
+    model: gpt-4o
+    snap: false
+    spinner: true
+    sync: false
+    verbose: false
+    wait: true

--- a/.pilot-commands.yaml
+++ b/.pilot-commands.yaml
@@ -56,17 +56,3 @@ commands:
     sync: true
     verbose: true
     wait: true
-- description: Ask a question about our K8s resources
-  name: k8s-question
-  params:
-    cheap: false
-    code: false
-    debug: false
-    direct: false
-    file: prompts/k8s-question.jinja2
-    model: gpt-4o
-    snap: false
-    spinner: true
-    sync: false
-    verbose: false
-    wait: true

--- a/cli/command_index.py
+++ b/cli/command_index.py
@@ -80,7 +80,6 @@ class CommandIndex:
         self.file_path = file_path
         if not self.file_path:
             self.file_path = find_pilot_commands_file()
-            print(f"Discovered commands file at {self.file_path}")
         self.commands = self._load_commands()
 
     def _load_commands(self) -> List[PilotCommand]:

--- a/cli/prompt_template.py
+++ b/cli/prompt_template.py
@@ -42,11 +42,12 @@ def sh(shell_command, status):
     result = subprocess.run(shell_command, **subprocess_params)
     if result.stderr:
         status.fail()
+        status.stop()
         console = Console()
         console.print(Padding(result.stderr, (1, 1)))
     else:
         status.success(start_again=False)
-    status.stop()
+        status.stop()
     result = (result.stdout + result.stderr).strip()
     return result
 

--- a/cli/prompt_template.py
+++ b/cli/prompt_template.py
@@ -2,36 +2,62 @@ import os
 import subprocess
 
 import click
+import inquirer
 import jinja2
 from pr_pilot.util import create_task
+from rich.console import Console
+from rich.padding import Padding
 from rich.prompt import Prompt
 
 from cli.task_handler import TaskHandler
+from cli.util import is_git_repo, get_git_root
 
 MAX_RECURSION_LEVEL = 3
+
+
+def select(prompt: str, choices: list[str]):
+    """Prompt the user to select one of the choices."""
+    questions = [
+        inquirer.List(
+            "choices",
+            message=prompt,
+            choices=choices,
+        ),
+    ]
+    response = inquirer.prompt(questions)
+    if not response:
+        raise click.Abort()
+    return response["choices"]
 
 
 def sh(shell_command, status):
     """Run a shell command and return the output"""
     status.start()
-    status.update(f"Running shell command: {shell_command}")
     if isinstance(shell_command, str):
         shell_command = shell_command.split()
-    subprocess_params = dict(stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    status.update(f"Running shell command: {' '.join(shell_command)}")
+    subprocess_params = dict(
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=os.environ.copy()
+    )
     result = subprocess.run(shell_command, **subprocess_params)
     if result.stderr:
         status.fail()
+        console = Console()
+        console.print(Padding(result.stderr, (1, 1)))
     else:
         status.success(start_again=False)
     status.stop()
-    return result.stdout + result.stderr
+    result = (result.stdout + result.stderr).strip()
+    return result
 
 
 def read_env_var(variable, default=None):
     """Get the value of an environment variable, with a default value."""
     if variable not in os.environ and default is None:
         # Ask for Variable input with click
-        os.environ[variable] = Prompt.ask(f"Enter value for {variable}")
+        prompt = variable.lower().replace("_", " ")
+        first_letter_capitalized = prompt[0].upper() + prompt[1:]
+        os.environ[variable] = Prompt.ask("> " + first_letter_capitalized)
     return os.environ.get(variable, default)
 
 
@@ -90,7 +116,14 @@ class PromptTemplate:
 
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.getcwd()))
         env.globals.update(env=read_env_var)
+        env.globals.update(select=select)
         env.globals.update(subtask=wrap_function_with_status(subtask, self.status))
         env.globals.update(sh=wrap_function_with_status(sh, self.status))
+
+        if is_git_repo():
+            git_root = get_git_root()
+            if git_root:
+                env.loader = jinja2.FileSystemLoader(git_root)
+
         template = env.get_template(self.template_file_path)
         return template.render(self.variables)

--- a/cli/status_indicator.py
+++ b/cli/status_indicator.py
@@ -22,7 +22,6 @@ class StatusIndicator:
             self.spinner.ok("✔")
             if start_again:
                 self.spinner.start()
-            self.spinner.start()
 
     def fail(self):
         if self.visible:

--- a/cli/util.py
+++ b/cli/util.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import subprocess
 from datetime import datetime, timezone
@@ -166,3 +167,33 @@ def markdown_panel(title, content):
     padding = 4  # Adjust padding as necessary
     width = max_line_length + padding
     return Panel.fit(Markdown(content), title=title, width=width)
+
+
+@functools.lru_cache()
+def is_git_repo():
+    """Check if the current directory is part of a Git repository."""
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+@functools.lru_cache()
+def get_git_root():
+    """Get the root directory of the current Git repository."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return result.stdout.decode("utf-8").strip()
+    except subprocess.CalledProcessError:
+        return None

--- a/prompts/investigate-pod.jinja2
+++ b/prompts/investigate-pod.jinja2
@@ -1,0 +1,10 @@
+{% set pod=select('Select a pod', sh('kubectl get pods -o custom-columns=:metadata.name').split('\n')) %}
+
+Here are the last 10 log lines of a Kubernetes pod named `{{ pod }}`:
+
+```shell
+{{ sh(['kubectl', '--tail=10', 'logs', pod]) }}
+```
+
+I want to know:
+{{ env('QUESTION_ABOUT_LOGS') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pr-pilot-cli"
-version = "1.11.12"
+version = "1.11.13"
 description = "CLI for PR Pilot, a text-to-task automation platform for Github."
 authors = ["Marco Lamina <marco@pr-pilot.ai>"]
 license = "GPL-3.0"


### PR DESCRIPTION
This PR introduces a new `select` command for prompt templates, enhancing the interactivity and flexibility of the CLI.

**Changes include:**

**Command Index Enhancements**
- Add `find_pilot_commands_file` to locate `.pilot-commands.yaml` in Git root or home directory
- Update `CommandIndex` to use `find_pilot_commands_file` if no file path is provided

**Prompt Template Enhancements**
- Introduce `select` function for user selection from a list
- Update `sh` function to handle environment variables
- Enhance `read_env_var` for better user prompts
- Update Jinja2 environment to include `select` and set loader to Git root if available

**Utility Functions**
- Add `is_git_repo` and `get_git_root` to check Git repository status and root directory

**Documentation**
- Update `prompts/README.md` to include usage of `select` function

**New Prompt Template**
- Add `prompts/investigate-pod.jinja2` for Kubernetes pod log investigation