### PR TITLE
✨ Always show PR in response

### DIFF
--- a/cli/command_index.py
+++ b/cli/command_index.py
@@ -126,6 +126,12 @@ def find_pilot_commands_file() -> Optional[str]:
             git_repo_file_path = os.path.join(git_root, ".pilot-commands.yaml")
             if os.path.isfile(git_repo_file_path):
                 return os.path.abspath(git_repo_file_path)
+            else:
+                # Create the file if it doesn't exist
+                with open(git_repo_file_path, "w") as file:
+                    file.write("commands: []")
+    else:
+        return None
 
     # If not found in the Git repository, check the home directory
     home_file_path = os.path.expanduser("~/.pilot-commands.yaml")

--- a/cli/task_handler.py
+++ b/cli/task_handler.py
@@ -83,7 +83,7 @@ class TaskHandler:
             self.status.stop()
             if result:
                 # If verbose mode is disabled, we still want to show the PR URL
-                if not verbose and new_pr_url:
+                if new_pr_url:
                     result += f"\n\n🆕 [**PR #{self.task.pr_number}**]({new_pr_url})"
                 if print_result:
                     self.console.print(markdown_panel("Result", result))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pr-pilot-cli"
-version = "1.13.0"
+version = "1.13.1"
 description = "CLI for PR Pilot, a text-to-task automation platform."
 authors = ["Marco Lamina <marco@pr-pilot.ai>"]
 license = "GPL-3.0"


### PR DESCRIPTION
This PR ensures that the PR URL is always shown in the response, regardless of the verbosity setting.

**Changes Made:**

- **Command File Handling**
  - Update [`cli/command_index.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/command-file/cli/command_index.py) to create `.pilot-commands.yaml` if it doesn't exist in the Git repository.

- **Task Handler**
  - Modify [`cli/task_handler.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/command-file/cli/task_handler.py) to always show the PR URL in the response.

- **Version Bump**
  - Update version in [`pyproject.toml`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/command-file/pyproject.toml) from `1.13.0` to `1.13.1`.