### PR TITLE
🔄 Enable Sync Option in Chat Mode

### DIFF
--- a/cli/commands/chat.py
+++ b/cli/commands/chat.py
@@ -137,7 +137,7 @@ def run_chat(branch, chat_history, console, ctx, task_runner):
             verbose=True,
             prompt=chat_history.to_prompt(),
             wait=True,
-            sync=False,
+            sync=ctx.obj["sync"],
             branch=branch,
             repo=ctx.obj["repo"],
             model=ctx.obj["model"],

--- a/cli/task_handler.py
+++ b/cli/task_handler.py
@@ -95,10 +95,6 @@ class TaskHandler:
                         f"{str(e)}. Retry {retry_count} of {max_retries}."
                     )
                     await asyncio.sleep(1)
-            except Exception as e:
-                self.status.fail(
-                    f"Unexpected error: {str(e)}. Retry {retry_count} of {max_retries}."
-                )
 
     async def write_result_to_file(self, code, message, output_file):
         """Write the result to a file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pr-pilot-cli"
-version = "1.14.2"
+version = "1.15.0"
 description = "CLI for PR Pilot, a text-to-task automation platform."
 authors = ["Marco Lamina <marco@pr-pilot.ai>"]
 license = "GPL-3.0"


### PR DESCRIPTION
This PR enables the sync option in chat mode and includes some additional improvements.

**Changes**
- Enable the sync option in chat mode by modifying the `run_chat` function in [`cli/commands/chat.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/chat-sync/cli/commands/chat.py).
- Remove the generic exception handler in [`cli/task_handler.py`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/chat-sync/cli/task_handler.py).
- Bump the version to 1.15.0 in [`pyproject.toml`](https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/chat-sync/pyproject.toml).