### PR TITLE
🔄 Rename PR Pilot to Arcane Engine

### DIFF
--- a/.pilot-commands.yaml
+++ b/.pilot-commands.yaml
@@ -8,7 +8,7 @@ commands:
     direct: false
     model: gpt-3.5-turbo
     prompt: write a haiku about this project
-    repo: PR-Pilot-AI/pr-pilot-cli
+    repo: arc-eng/cli
     snap: false
     spinner: true
     sync: false

--- a/.pilot-hints.md
+++ b/.pilot-hints.md
@@ -1,5 +1,5 @@
-PR Pilot is a tool that lets developers delegate small tasks to AI in natural language to save time and avoid context switching.
-Every interaction between the user and PR Pilot is a task. Tasks are created using prompts.
+Arcane Engine is a tool that lets developers delegate small tasks to AI in natural language to save time and avoid context switching.
+Every interaction between the user and Arcane Engine is a task. Tasks are created using prompts.
 This project:
 - Uses `click` to implement CLI in Python
 - Main entry point is the `pilot` command in `cli/cli.py`

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@
 
 # Arcane Engine Command-Line Interface
 [![Unit Tests](https://github.com/arc-eng/cli/actions/workflows/unit_tests.yml/badge.svg)][tests]
-[![PyPI](https://img.shields.io/pypi/v/arcane-engine-cli.svg)][pypi status]
-[![Python Version](https://img.shields.io/pypi/pyversions/arcane-engine-cli)][pypi status]
-[![License](https://img.shields.io/pypi/l/arcane-engine-cli)][license]
+[![PyPI](https://img.shields.io/pypi/v/arcane-cli.svg)][pypi status]
+[![Python Version](https://img.shields.io/pypi/pyversions/arcane-cli)][pypi status]
+[![License](https://img.shields.io/pypi/l/arcane-cli)][license]
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)][black]
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)][pre-commit]
 <br>
 
-[pypi status]: https://pypi.org/project/arcane-engine-cli/
+[pypi status]: https://pypi.org/project/arcane-cli/
 [tests]: https://github.com/arc-eng/cli/actions/workflows/unit_tests.yml
 [codecov]: https://app.codecov.io/gh/magmax/python-inquirer
 [pre-commit]: https://github.com/pre-commit/pre-commit
@@ -100,13 +100,13 @@ Then, install the CLI using one of the following methods:
 
 ### pip
 ```
-pip install --upgrade arcane-engine-cli
+pip install --upgrade arcane-cli
 ```
 
 ### Homebrew:
 ```
 brew tap pr-pilot-ai/homebrew-tap
-brew install arcane-engine-cli
+brew install arcane-cli
 ```
 
 
@@ -143,7 +143,7 @@ Commands:
   plan     📋 Let Arcane Engine execute a plan for you.
   run      🚀 Run a saved command.
   task     ➕ Create a new task for Arcane Engine.
-  upgrade  ⬆️ Upgrade arcane-engine-cli to the latest version.
+  upgrade  ⬆️ Upgrade arcane-cli to the latest version.
 ```
 
 ## 🛠️ Usage

--- a/README.md
+++ b/README.md
@@ -1,44 +1,44 @@
 <div align="center">
-<img src="https://avatars.githubusercontent.com/ml/17635?s=140&v=" width="100" alt="PR Pilot Logo">
+<img src="https://avatars.githubusercontent.com/ml/17635?s=140&v=" width="100" alt="Arcane Engine Logo">
 </div>
 
 <p align="center">
   <a href="https://github.com/apps/pr-pilot-ai/installations/new"><b>Install</b></a> |
-  <a href="https://docs.pr-pilot.ai">Documentation</a> |
-  <a href="https://www.pr-pilot.ai/blog">Blog</a> |
-  <a href="https://www.pr-pilot.ai">Website</a>
+  <a href="https://docs.arcane.engineer">Documentation</a> |
+  <a href="https://arcane.engineer/blog">Blog</a> |
+  <a href="https://arcane.engineer">Website</a>
 </p>
 
 
-# PR Pilot Command-Line Interface
-[![Unit Tests](https://github.com/PR-Pilot-AI/pr-pilot-cli/actions/workflows/unit_tests.yml/badge.svg)][tests]
-[![PyPI](https://img.shields.io/pypi/v/pr-pilot-cli.svg)][pypi status]
-[![Python Version](https://img.shields.io/pypi/pyversions/pr-pilot-cli)][pypi status]
-[![License](https://img.shields.io/pypi/l/pr-pilot-cli)][license]
+# Arcane Engine Command-Line Interface
+[![Unit Tests](https://github.com/arc-eng/cli/actions/workflows/unit_tests.yml/badge.svg)][tests]
+[![PyPI](https://img.shields.io/pypi/v/arcane-engine-cli.svg)][pypi status]
+[![Python Version](https://img.shields.io/pypi/pyversions/arcane-engine-cli)][pypi status]
+[![License](https://img.shields.io/pypi/l/arcane-engine-cli)][license]
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)][black]
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)][pre-commit]
 <br>
 
-[pypi status]: https://pypi.org/project/pr-pilot-cli/
-[tests]: https://github.com/PR-Pilot-AI/pr-pilot-cli/actions/workflows/unit_tests.yml
+[pypi status]: https://pypi.org/project/arcane-engine-cli/
+[tests]: https://github.com/arc-eng/cli/actions/workflows/unit_tests.yml
 [codecov]: https://app.codecov.io/gh/magmax/python-inquirer
 [pre-commit]: https://github.com/pre-commit/pre-commit
 [black]: https://github.com/psf/black
-[license]: https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/main/LICENSE
+[license]: https://github.com/arc-eng/cli/blob/main/LICENSE
 
-[PR Pilot](https://docs.pr-pilot.ai) is **simple and intuitive CLI** that assists you in your daily work:
+[Arcane Engine](https://docs.arcane.engineer) is **simple and intuitive CLI** that assists you in your daily work:
 
 ```bash
 pilot edit main.py "Add docstrings to all functions and classes"
 ```
 
-**It works with [the dev tools you trust and love](https://docs.pr-pilot.ai/integrations.html)** - exactly when and where you want it.
+**It works with [the dev tools you trust and love](https://docs.arcane.engineer/integrations.html)** - exactly when and where you want it.
 
 ```bash
 pilot task "Find all bug issues on Github and Linear opened yesterday, post them to #bugs-daily on Slack."
 ```
 
-[Prompt templates](https://github.com/PR-Pilot-AI/pr-pilot-cli/tree/main/prompts) let you can create powerful,
+[Prompt templates](https://github.com/arc-eng/cli/tree/main/prompts) let you can create powerful,
 **executable prompt-based commands**, defined as Jinja templates:
 
 ```markdown
@@ -57,7 +57,7 @@ Use the following guidelines:
 Edit PR #{{ env('PR_NUMBER') }} title and description to reflect the changes made in this PR.
 ```
 
-Send PR Pilot off to give any PR a title and description **according to your guidelines**:
+Send Arcane Engine off to give any PR a title and description **according to your guidelines**:
 
 ```bash
 ➜ PR_NUMBER=153 pilot task -f generate-pr-description.md.jinja2 --save-command
@@ -91,22 +91,22 @@ Enter value for PR_NUMBER: 83
 ╰─────────────────────────────────╯
 ```
 
-To learn more, please visit our **[User Guide](https://docs.pr-pilot.ai/user_guide.html)** and **[demo repository](https://github.com/PR-Pilot-AI/demo/tree/main)**.
+To learn more, please visit our **[User Guide](https://docs.arcane.engineer/user_guide.html)** and **[demo repository](https://github.com/PR-Pilot-AI/demo/tree/main)**.
 
 ## 📦 Installation
-First, make sure you have [installed](https://github.com/apps/pr-pilot-ai/installations/new) PR Pilot in your repository.
+First, make sure you have [installed](https://github.com/apps/pr-pilot-ai/installations/new) Arcane Engine in your repository.
 
 Then, install the CLI using one of the following methods:
 
 ### pip
 ```
-pip install --upgrade pr-pilot-cli
+pip install --upgrade arcane-engine-cli
 ```
 
 ### Homebrew:
 ```
 brew tap pr-pilot-ai/homebrew-tap
-brew install pr-pilot-cli
+brew install arcane-engine-cli
 ```
 
 
@@ -118,32 +118,32 @@ The CLI has global parameters and options that can be used to customize its beha
 ```bash
 Usage: pilot [OPTIONS] COMMAND [ARGS]...
 
-  PR Pilot CLI - https://docs.pr-pilot.ai
+  Arcane Engine CLI - https://docs.arcane.engineer
 
   Delegate routine work to AI with confidence and predictability.
 
 Options:
-  --wait / --no-wait        Wait for PR Pilot to finish the task.
+  --wait / --no-wait        Wait for Arcane Engine to finish the task.
   --repo TEXT               Github repository in the format owner/repo.
   --spinner / --no-spinner  Display a loading indicator.
   --verbose                 Display status messages
   -m, --model TEXT          GPT model to use.
   -b, --branch TEXT         Run the task on a specific branch.
-  --sync / --no-sync        Run task on your current branch and pull PR Pilots
+  --sync / --no-sync        Run task on your current branch and pull Arcane Engines
                             changes when done.
   --debug                   Display debug information.
   --help                    Show this message and exit.
 
 Commands:
-  chat     💬 Chat with PR Pilot.
-  config   🔧 Customize PR Pilots behavior.
-  edit     ✍️ Let PR Pilot edit a file for you.
+  chat     💬 Chat with Arcane Engine.
+  config   🔧 Customize Arcane Engines behavior.
+  edit     ✍️ Let Arcane Engine edit a file for you.
   grab     🤲 Grab commands, prompts and plans from other repositories.
   history  📜 Access recent tasks.
-  plan     📋 Let PR Pilot execute a plan for you.
+  plan     📋 Let Arcane Engine execute a plan for you.
   run      🚀 Run a saved command.
-  task     ➕ Create a new task for PR Pilot.
-  upgrade  ⬆️ Upgrade pr-pilot-cli to the latest version.
+  task     ➕ Create a new task for Arcane Engine.
+  upgrade  ⬆️ Upgrade arcane-engine-cli to the latest version.
 ```
 
 ## 🛠️ Usage
@@ -152,7 +152,7 @@ In your repository, use the `pilot` command:
 
 ```bash
 pilot task "Tell me about this project!"
-# 📝 Ask PR Pilot to edit a local file for you:
+# 📝 Ask Arcane Engine to edit a local file for you:
 pilot edit cli/cli.py "Make sure all functions and classes have docstrings."
 # ⚡ Generate code quickly and save it as a file:
 pilot task -o test_utils.py --code "Write some unit tests for the utils.py file."
@@ -160,7 +160,7 @@ pilot task -o test_utils.py --code "Write some unit tests for the utils.py file.
 pilot task -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
 # 📊 Get an organized view of your Github issues:
 pilot task "Find all open Github issues labeled as 'bug', categorize and prioritize them"
-# 📝 Ask PR Pilot to analyze your test results using prompt templates:
+# 📝 Ask Arcane Engine to analyze your test results using prompt templates:
 pilot task -f prompts/analyze-test-results.md.jinja2
 ```
 
@@ -238,7 +238,7 @@ You can run this plan with:
 pilot plan add_page.yaml
 ```
 
-PR Pilot will then autonomously:
+Arcane Engine will then autonomously:
 * Create a new branch and open a PR
 * Implement the HTML template and view controller
 * Integrate the new page into the navigation
@@ -271,4 +271,4 @@ verbose: false
 Contributors are welcome to improve the CLI by submitting pull requests or reporting issues. For more details, check the project's GitHub repository.
 
 ## 📜 License
-The PR Pilot CLI is open-source software licensed under the GPL-3 license.
+The Arcane Engine CLI is open-source software licensed under the GPL-3 license.

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -20,7 +20,7 @@ from cli.user_config import UserConfig
     "--wait/--no-wait",
     is_flag=True,
     default=True,
-    help="Wait for PR Pilot to finish the task.",
+    help="Wait for Arcane Engine to finish the task.",
 )
 @click.option("--repo", help="Github repository in the format owner/repo.", required=False)
 @click.option(
@@ -42,13 +42,13 @@ from cli.user_config import UserConfig
     "--sync/--no-sync",
     is_flag=True,
     default=None,
-    help="Run task on your current branch and pull PR Pilots changes when done.",
+    help="Run task on your current branch and pull Arcane Engines changes when done.",
 )
 @click.option("--debug", is_flag=True, default=False, help="Display debug information.")
 @click.pass_context
 
 def main(ctx, wait, repo, spinner, verbose, model, branch, sync, debug):
-    """PR Pilot CLI - https://docs.pr-pilot.ai
+    """Arcane Engine CLI - https://docs.arcane.engineer
 
     Delegate routine work to AI with confidence and predictability.
     """

--- a/cli/command_index.py
+++ b/cli/command_index.py
@@ -94,7 +94,7 @@ class PilotCommand(BaseModel):
         cmd.params.append(
             click.Option(
                 ["--sync/--no-sync"],
-                help="🔄 Sync local repository state with PR Pilot changes.",
+                help="🔄 Sync local repository state with Arcane Engine changes.",
                 is_flag=True,
                 default=self.params.sync,
             )

--- a/cli/commands/chat.py
+++ b/cli/commands/chat.py
@@ -82,7 +82,7 @@ class ChatHistory(BaseModel):
 )
 @click.pass_context
 def chat(ctx, branch, history):
-    """💬 Chat with PR Pilot."""
+    """💬 Chat with Arcane Engine."""
     console = Console()
     status_indicator = StatusIndicator(
         display_log_messages=True, spinner=True, console=console, display_spinner_text=False

--- a/cli/commands/config.py
+++ b/cli/commands/config.py
@@ -9,7 +9,7 @@ from cli.constants import CONFIG_LOCATION
 
 @click.group()
 def config():
-    """🔧 Customize PR Pilots behavior."""
+    """🔧 Customize Arcane Engines behavior."""
     pass
 
 

--- a/cli/commands/edit.py
+++ b/cli/commands/edit.py
@@ -16,7 +16,7 @@ from cli.util import pull_branch_changes
 @click.argument("prompt", required=False, default=None, type=str)
 @click.pass_context
 def edit(ctx, snap, file_path, prompt):
-    """✍️ Let PR Pilot edit a file for you.
+    """✍️ Let Arcane Engine edit a file for you.
 
     Examples:
 

--- a/cli/commands/grab.py
+++ b/cli/commands/grab.py
@@ -28,7 +28,7 @@ def grab(ctx):
 def grab_commands(ctx, repo):
     """🤲 Grab commands from a Github repository (owner/repo).
 
-    Example: pilot grab commands pr-pilot-ai/pr-pilot-cli
+    Example: pilot grab commands arc-eng/cli
     """
     console = Console()
     status_indicator = StatusIndicator(
@@ -64,7 +64,7 @@ def grab_commands(ctx, repo):
 def grab_skills(ctx, repo):
     """🤲 Grab skills from a Github repository (owner/repo).
 
-    Example: pilot grab skills pr-pilot-ai/pr-pilot-cli
+    Example: pilot grab skills arc-eng/cli
     """
     console = Console()
     status_indicator = StatusIndicator(

--- a/cli/commands/plan.py
+++ b/cli/commands/plan.py
@@ -10,9 +10,9 @@ from cli.util import pull_branch_changes, get_branch_if_pushed
 @click.argument("file_path", type=click.Path(exists=True))
 @click.pass_context
 def plan(ctx, file_path):
-    """📋 Let PR Pilot execute a plan for you.
+    """📋 Let Arcane Engine execute a plan for you.
 
-    Learn more: https://docs.pr-pilot.ai/user_guide.html
+    Learn more: https://docs.arcane.engineer/user_guide.html
     """
     console = Console()
     status_indicator = StatusIndicator(

--- a/cli/commands/task.py
+++ b/cli/commands/task.py
@@ -40,7 +40,7 @@ from cli.util import get_branch_if_pushed
     "--direct",
     is_flag=True,
     default=False,
-    help="🔄 Do not feed the rendered template as a prompt into PR Pilot, "
+    help="🔄 Do not feed the rendered template as a prompt into Arcane Engine, "
     "but render it directly as output.",
 )
 @click.option(
@@ -57,9 +57,9 @@ from cli.util import get_branch_if_pushed
 @click.argument("prompt", required=False, default=None, type=str)
 @click.pass_context
 def task(ctx, snap, cheap, code, file, direct, output, save_command, prompt):
-    """➕ Create a new task for PR Pilot.
+    """➕ Create a new task for Arcane Engine.
 
-    Examples: https://github.com/pr-pilot-ai/pr-pilot-cli
+    Examples: https://github.com/arc-eng/cli
     """
     console = Console()
     status_indicator = StatusIndicator(

--- a/cli/commands/upgrade.py
+++ b/cli/commands/upgrade.py
@@ -7,21 +7,21 @@ from rich.prompt import Confirm
 
 @click.command()
 def upgrade():
-    """⬆️ Upgrade pr-pilot-cli to the latest version."""
+    """⬆️ Upgrade arcane-engine-cli to the latest version."""
     if is_installed_via_homebrew():
         if Confirm.ask(
-            "Found homebrew installation. Upgrade the [code]pr-pilot-cli[/code] package?"
+            "Found homebrew installation. Upgrade the [code]arcane-engine-cli[/code] package?"
         ):
             subprocess.run(["brew", "update"], check=True)
-            subprocess.run(["brew", "upgrade", "pr-pilot-cli"], check=True)
+            subprocess.run(["brew", "upgrade", "arcane-engine-cli"], check=True)
     else:
-        if Confirm.ask("Upgrade the [code]pr-pilot-cli[/code] package with pip?"):
+        if Confirm.ask("Upgrade the [code]arcane-engine-cli[/code] package with pip?"):
             subprocess.run(
-                [sys.executable, "-m", "pip", "install", "--upgrade", "pr-pilot-cli"], check=True
+                [sys.executable, "-m", "pip", "install", "--upgrade", "arcane-engine-cli"], check=True
             )
 
 
 def is_installed_via_homebrew() -> bool:
-    """Check if pr-pilot-cli is installed via Homebrew."""
-    result = subprocess.run(["brew", "list", "pr-pilot-cli"], capture_output=True)
+    """Check if arcane-engine-cli is installed via Homebrew."""
+    result = subprocess.run(["brew", "list", "arcane-engine-cli"], capture_output=True)
     return result.returncode == 0

--- a/cli/commands/upgrade.py
+++ b/cli/commands/upgrade.py
@@ -7,21 +7,21 @@ from rich.prompt import Confirm
 
 @click.command()
 def upgrade():
-    """⬆️ Upgrade arcane-engine-cli to the latest version."""
+    """⬆️ Upgrade arcane-cli to the latest version."""
     if is_installed_via_homebrew():
         if Confirm.ask(
-            "Found homebrew installation. Upgrade the [code]arcane-engine-cli[/code] package?"
+            "Found homebrew installation. Upgrade the [code]arcane-cli[/code] package?"
         ):
             subprocess.run(["brew", "update"], check=True)
-            subprocess.run(["brew", "upgrade", "arcane-engine-cli"], check=True)
+            subprocess.run(["brew", "upgrade", "arcane-cli"], check=True)
     else:
-        if Confirm.ask("Upgrade the [code]arcane-engine-cli[/code] package with pip?"):
+        if Confirm.ask("Upgrade the [code]arcane-cli[/code] package with pip?"):
             subprocess.run(
-                [sys.executable, "-m", "pip", "install", "--upgrade", "arcane-engine-cli"], check=True
+                [sys.executable, "-m", "pip", "install", "--upgrade", "arcane-cli"], check=True
             )
 
 
 def is_installed_via_homebrew() -> bool:
-    """Check if arcane-engine-cli is installed via Homebrew."""
-    result = subprocess.run(["brew", "list", "arcane-engine-cli"], capture_output=True)
+    """Check if arcane-cli is installed via Homebrew."""
+    result = subprocess.run(["brew", "list", "arcane-cli"], capture_output=True)
     return result.returncode == 0

--- a/cli/models.py
+++ b/cli/models.py
@@ -23,5 +23,5 @@ class TaskParameters(BaseModel):
     pr_number: Optional[int] = Field(default=None, description="Pull request number")
     spinner: bool = Field(default=True, description="Display spinners")
     sync: bool = Field(
-        default=False, description="Sync local repository state with PR Pilot changes"
+        default=False, description="Sync local repository state with Arcane Engine changes"
     )

--- a/cli/plan_executor.py
+++ b/cli/plan_executor.py
@@ -30,7 +30,7 @@ class PlanExecutor:
     def run(self, wait, repo, verbose, model, debug):
         """Run all steps in a given plan
 
-        :param wait: Wait for PR Pilot to finish the plan
+        :param wait: Wait for Arcane Engine to finish the plan
         :param repo: Github repository in the format owner/repo
         :param verbose: Display more status messages
         :param model: GPT model to use

--- a/cli/skill_index.py
+++ b/cli/skill_index.py
@@ -20,7 +20,7 @@ yaml.add_representer(str, str_presenter)
 
 
 class AgentSkill(BaseModel):
-    """User-defined skill for the PR Pilot agent."""
+    """User-defined skill for the Arcane Engine agent."""
 
     title: str = Field(..., title="Short title of the skill")
     args: Optional[dict] = Field(None, title="Arguments required to perform the skill")

--- a/cli/user_config.py
+++ b/cli/user_config.py
@@ -98,7 +98,7 @@ class UserConfig:
 
     def collect_user_preferences(self):
         console.print(
-            "Since it's the first time you're using PR Pilot, " "let's set some default values."
+            "Since it's the first time you're using Arcane Engine, " "let's set some default values."
         )
         auto_sync = Confirm.ask(
             "When a new PR/branch is created, do you want it checked out automatically?",
@@ -124,7 +124,7 @@ class UserConfig:
         return self.config.get("verbose", False)
 
     def authenticate(self) -> str:
-        """Authenticate the CLI with PR Pilot."""
+        """Authenticate the CLI with Arcane Engine."""
         key_name = f"CLI on {socket.gethostname()}"
         callback_url = f"http://localhost:{PORT}/callback"
         auth_url = f"{get_api_host()}/dashboard/cli-auth/?name={key_name}&callback={callback_url}"

--- a/examples/extract-project-template/template.md
+++ b/examples/extract-project-template/template.md
@@ -1,5 +1,5 @@
 ### Project Structure and Dependencies
-Here's the information you requested about the `PR-Pilot-AI/pr-pilot-cli` project:
+Here's the information you requested about the `arc-eng/cli` project:
 
 1. **Primary Language and Framework:**
    - The project primarily uses Python. This is inferred from the presence of Python-specific files like `requirements.txt` and `setup.py`.
@@ -34,14 +34,14 @@ Here's the information you requested about the `PR-Pilot-AI/pr-pilot-cli` projec
 These details provide a comprehensive overview of the project's technical and legal setup.
 
 ### README File
-The `README.md` file for the PR Pilot CLI project is structured and organized as follows:
+The `README.md` file for the Arcane Engine CLI project is structured and organized as follows:
 
 ### Structure and Sections:
 1. **Header**: Includes a centered logo and navigation links (Install, Documentation, Blog, Website).
-2. **Introduction**: Briefly describes the purpose and functionality of PR Pilot CLI.
+2. **Introduction**: Briefly describes the purpose and functionality of Arcane Engine CLI.
 3. **Usage**: Explains how to use the CLI with examples for various tasks.
 4. **Options and Parameters**: Detailed list of command-line options and parameters.
-5. **Installation**: Steps to install PR Pilot CLI via pip and Homebrew.
+5. **Installation**: Steps to install Arcane Engine CLI via pip and Homebrew.
 6. **Configuration**: Information about the configuration file location.
 7. **Contributing**: Encourages contributions and links to the GitHub repository.
 8. **License**: Specifies the licensing information (GPL-3).
@@ -57,10 +57,10 @@ The `README.md` file for the PR Pilot CLI project is structured and organized as
 ### Use of Emojis:
 - The README does not use emojis within the text. It maintains a professional tone suitable for a technical document.
 
-This structure ensures that users can quickly find the information they need about installation, usage, and customization of the PR Pilot CLI.
+This structure ensures that users can quickly find the information they need about installation, usage, and customization of the Arcane Engine CLI.
 
 ### Build System & CI/CD
-### Build System Details of the PR Pilot CLI Project
+### Build System Details of the Arcane Engine CLI Project
 
 **Build System Used:**
 - The project uses `Makefile` as its build system.
@@ -91,4 +91,4 @@ This structure ensures that users can quickly find the information they need abo
 - The `.github` directory contains the CI/CD workflows.
 - The `Makefile` can also be part of the CI/CD process, as it defines how to build and test the project.
 
-These details should give you a comprehensive understanding of the build system used in the PR Pilot CLI project. If you need more specific details about any of the components, feel free to ask!
+These details should give you a comprehensive understanding of the build system used in the Arcane Engine CLI project. If you need more specific details about any of the components, feel free to ask!

--- a/homebrew_formula.rb
+++ b/homebrew_formula.rb
@@ -1,8 +1,8 @@
 class PrPilotCli < Formula
   include Language::Python::Virtualenv
 
-  desc "CLI for PR Pilot, a text-to-task automation platform for Github."
-  homepage "https://www.pr-pilot.ai"
+  desc "CLI for Arcane Engine, a text-to-task automation platform for Github."
+  homepage "https://arcane.engineer"
   license "GPL-3.0"
 
 {{ PACKAGE_URL }}

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -2,7 +2,7 @@
 
 ## What are Prompt Templates?
 
-Prompt templates in PR Pilot are a superset of [Jinja templates](https://jinja.palletsprojects.com/en/3.1.x/),
+Prompt templates in Arcane Engine are a superset of [Jinja templates](https://jinja.palletsprojects.com/en/3.1.x/),
 with three special functions available:
 
 - `sh`: Execute shell commands and capture the output.
@@ -34,14 +34,14 @@ If the tests are green, do nothing. Otherwise:
 ### Explanation:
 
 The goal is to dynamically generate a prompt that includes the output of running unit tests and provides instructions 
-for PR Pilot on how to analyze the results. Here's what each part does:
+for Arcane Engine on how to analyze the results. Here's what each part does:
 
 - `{{ sh('pytest') }}`: This line dynamically inserts the output of the `pytest` command, which runs unit tests.
 - `{% if env('PR_NUMBER') %}`: This conditional block checks if a PR number is set in the environment (e.g. when run as a Github Action). If it is, it includes a step to comment on the PR with the analysis of the test results.
 
 ## How to Use Prompt Templates
 
-To use a prompt template, you can pass it as a file to PR Pilot using the `-f` or `--file` option. For example:
+To use a prompt template, you can pass it as a file to Arcane Engine using the `-f` or `--file` option. For example:
 
 ```bash
 pilot -f analyze_test_results.md.jinja2
@@ -50,7 +50,7 @@ pilot -f analyze_test_results.md.jinja2
 This will trigger the following:
 1. Run the tests in the local environment
 2. Capture the output of the tests as part of the prompt
-3. Send the prompt to PR Pilot, where it will autonomously:
+3. Send the prompt to Arcane Engine, where it will autonomously:
     1. Read the test results and identify failing parts
     2. Read the relevant files to understand the problem
     3. Write a structured analysis of the test results
@@ -69,9 +69,9 @@ multiple subtasks for generating documentation for different parts of the codeba
 Here's a simplified example:
 
 ```markdown
-# Task Processing in PR Pilot
+# Task Processing in Arcane Engine
 
-The lifecycle of a task within PR Pilot involves several key components: `TaskEngine`, `TaskScheduler`, and `TaskWorker`.
+The lifecycle of a task within Arcane Engine involves several key components: `TaskEngine`, `TaskScheduler`, and `TaskWorker`.
 
 ## Domain Model
 
@@ -82,7 +82,7 @@ Read the following files:
 - engine/task_worker.py
 - engine/task.py
 
-Generate a Mermaid class diagram to illustrate the domain model of the task processing in PR Pilot. Add a clear and concise text description.
+Generate a Mermaid class diagram to illustrate the domain model of the task processing in Arcane Engine. Add a clear and concise text description.
 {% endset %}
 
 {{ subtask(domain_model_prompt) }}
@@ -106,9 +106,9 @@ In this example, the `subtask` function is used to generate a class diagram and 
 For better readability and maintainability, the prompts could even be stored in their own separate files and included in the main prompt template:
 
 ```markdown
-# Task Processing in PR Pilot
+# Task Processing in Arcane Engine
 
-The lifecycle of a task within PR Pilot involves several key components: `TaskEngine`, `TaskScheduler`, and `TaskWorker`.
+The lifecycle of a task within Arcane Engine involves several key components: `TaskEngine`, `TaskScheduler`, and `TaskWorker`.
 
 ## Domain Model
 
@@ -127,7 +127,7 @@ pilot --direct -f task_processing_docs.md.jinja2 -o docs/task_processing.md
 This will autonomously generate the documentation for the codebase based on the defined subtasks in the prompt template:
 - `-f` specifies the prompt template file
 - `-o` specifies the output file where the generated documentation will be saved
-- `--direct` tells PR Pilot to render the template directly as output (instead of using it as a prompt)
+- `--direct` tells Arcane Engine to render the template directly as output (instead of using it as a prompt)
 
 
 ## Select values from a list with `select`

--- a/prompts/README.md.jinja2
+++ b/prompts/README.md.jinja2
@@ -12,14 +12,14 @@
 
 # Arcane Engine Command-Line Interface
 [![Unit Tests](https://github.com/arc-eng/cli/actions/workflows/unit_tests.yml/badge.svg)][tests]
-[![PyPI](https://img.shields.io/pypi/v/arcane-engine-cli.svg)][pypi status]
-[![Python Version](https://img.shields.io/pypi/pyversions/arcane-engine-cli)][pypi status]
-[![License](https://img.shields.io/pypi/l/arcane-engine-cli)][license]
+[![PyPI](https://img.shields.io/pypi/v/arcane-cli.svg)][pypi status]
+[![Python Version](https://img.shields.io/pypi/pyversions/arcane-cli)][pypi status]
+[![License](https://img.shields.io/pypi/l/arcane-cli)][license]
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)][black]
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)][pre-commit]
 <br>
 
-[pypi status]: https://pypi.org/project/arcane-engine-cli/
+[pypi status]: https://pypi.org/project/arcane-cli/
 [tests]: https://github.com/arc-eng/cli/actions/workflows/unit_tests.yml
 [codecov]: https://app.codecov.io/gh/magmax/python-inquirer
 [pre-commit]: https://github.com/pre-commit/pre-commit
@@ -100,13 +100,13 @@ Then, install the CLI using one of the following methods:
 
 ### pip
 ```
-pip install --upgrade arcane-engine-cli
+pip install --upgrade arcane-cli
 ```
 
 ### Homebrew:
 ```
 brew tap pr-pilot-ai/homebrew-tap
-brew install arcane-engine-cli
+brew install arcane-cli
 ```
 
 

--- a/prompts/README.md.jinja2
+++ b/prompts/README.md.jinja2
@@ -1,44 +1,44 @@
 <div align="center">
-<img src="https://avatars.githubusercontent.com/ml/17635?s=140&v=" width="100" alt="PR Pilot Logo">
+<img src="https://avatars.githubusercontent.com/ml/17635?s=140&v=" width="100" alt="Arcane Engine Logo">
 </div>
 
 <p align="center">
   <a href="https://github.com/apps/pr-pilot-ai/installations/new"><b>Install</b></a> |
-  <a href="https://docs.pr-pilot.ai">Documentation</a> |
-  <a href="https://www.pr-pilot.ai/blog">Blog</a> |
-  <a href="https://www.pr-pilot.ai">Website</a>
+  <a href="https://docs.arcane.engineer">Documentation</a> |
+  <a href="https://arcane.engineer/blog">Blog</a> |
+  <a href="https://arcane.engineer">Website</a>
 </p>
 
 
-# PR Pilot Command-Line Interface
-[![Unit Tests](https://github.com/PR-Pilot-AI/pr-pilot-cli/actions/workflows/unit_tests.yml/badge.svg)][tests]
-[![PyPI](https://img.shields.io/pypi/v/pr-pilot-cli.svg)][pypi status]
-[![Python Version](https://img.shields.io/pypi/pyversions/pr-pilot-cli)][pypi status]
-[![License](https://img.shields.io/pypi/l/pr-pilot-cli)][license]
+# Arcane Engine Command-Line Interface
+[![Unit Tests](https://github.com/arc-eng/cli/actions/workflows/unit_tests.yml/badge.svg)][tests]
+[![PyPI](https://img.shields.io/pypi/v/arcane-engine-cli.svg)][pypi status]
+[![Python Version](https://img.shields.io/pypi/pyversions/arcane-engine-cli)][pypi status]
+[![License](https://img.shields.io/pypi/l/arcane-engine-cli)][license]
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)][black]
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)][pre-commit]
 <br>
 
-[pypi status]: https://pypi.org/project/pr-pilot-cli/
-[tests]: https://github.com/PR-Pilot-AI/pr-pilot-cli/actions/workflows/unit_tests.yml
+[pypi status]: https://pypi.org/project/arcane-engine-cli/
+[tests]: https://github.com/arc-eng/cli/actions/workflows/unit_tests.yml
 [codecov]: https://app.codecov.io/gh/magmax/python-inquirer
 [pre-commit]: https://github.com/pre-commit/pre-commit
 [black]: https://github.com/psf/black
-[license]: https://github.com/PR-Pilot-AI/pr-pilot-cli/blob/main/LICENSE
+[license]: https://github.com/arc-eng/cli/blob/main/LICENSE
 
-[PR Pilot](https://docs.pr-pilot.ai) is **simple and intuitive CLI** that assists you in your daily work:
+[Arcane Engine](https://docs.arcane.engineer) is **simple and intuitive CLI** that assists you in your daily work:
 
 ```bash
 pilot edit main.py "Add docstrings to all functions and classes"
 ```
 
-**It works with [the dev tools you trust and love](https://docs.pr-pilot.ai/integrations.html)** - exactly when and where you want it.
+**It works with [the dev tools you trust and love](https://docs.arcane.engineer/integrations.html)** - exactly when and where you want it.
 
 ```bash
 pilot task "Find all bug issues on Github and Linear opened yesterday, post them to #bugs-daily on Slack."
 ```
 
-[Prompt templates](https://github.com/PR-Pilot-AI/pr-pilot-cli/tree/main/prompts) let you can create powerful,
+[Prompt templates](https://github.com/arc-eng/cli/tree/main/prompts) let you can create powerful,
 **executable prompt-based commands**, defined as Jinja templates:
 
 ```markdown
@@ -57,7 +57,7 @@ Use the following guidelines:
 Edit PR #{% raw %}{{ env('PR_NUMBER') }}{% endraw %} title and description to reflect the changes made in this PR.
 ```
 
-Send PR Pilot off to give any PR a title and description **according to your guidelines**:
+Send Arcane Engine off to give any PR a title and description **according to your guidelines**:
 
 ```bash
 ➜ PR_NUMBER=153 pilot task -f generate-pr-description.md.jinja2 --save-command
@@ -91,22 +91,22 @@ Enter value for PR_NUMBER: 83
 ╰─────────────────────────────────╯
 ```
 
-To learn more, please visit our **[User Guide](https://docs.pr-pilot.ai/user_guide.html)** and **[demo repository](https://github.com/PR-Pilot-AI/demo/tree/main)**.
+To learn more, please visit our **[User Guide](https://docs.arcane.engineer/user_guide.html)** and **[demo repository](https://github.com/PR-Pilot-AI/demo/tree/main)**.
 
 ## 📦 Installation
-First, make sure you have [installed](https://github.com/apps/pr-pilot-ai/installations/new) PR Pilot in your repository.
+First, make sure you have [installed](https://github.com/apps/pr-pilot-ai/installations/new) Arcane Engine in your repository.
 
 Then, install the CLI using one of the following methods:
 
 ### pip
 ```
-pip install --upgrade pr-pilot-cli
+pip install --upgrade arcane-engine-cli
 ```
 
 ### Homebrew:
 ```
 brew tap pr-pilot-ai/homebrew-tap
-brew install pr-pilot-cli
+brew install arcane-engine-cli
 ```
 
 
@@ -125,7 +125,7 @@ In your repository, use the `pilot` command:
 
 ```bash
 pilot task "Tell me about this project!"
-# 📝 Ask PR Pilot to edit a local file for you:
+# 📝 Ask Arcane Engine to edit a local file for you:
 pilot edit cli/cli.py "Make sure all functions and classes have docstrings."
 # ⚡ Generate code quickly and save it as a file:
 pilot task -o test_utils.py --code "Write some unit tests for the utils.py file."
@@ -133,7 +133,7 @@ pilot task -o test_utils.py --code "Write some unit tests for the utils.py file.
 pilot task -o component.html --code --snap "Write a Bootstrap5 component that looks like this."
 # 📊 Get an organized view of your Github issues:
 pilot task "Find all open Github issues labeled as 'bug', categorize and prioritize them"
-# 📝 Ask PR Pilot to analyze your test results using prompt templates:
+# 📝 Ask Arcane Engine to analyze your test results using prompt templates:
 pilot task -f prompts/analyze-test-results.md.jinja2
 ```
 
@@ -211,7 +211,7 @@ You can run this plan with:
 pilot plan add_page.yaml
 ```
 
-PR Pilot will then autonomously:
+Arcane Engine will then autonomously:
 * Create a new branch and open a PR
 * Implement the HTML template and view controller
 * Integrate the new page into the navigation
@@ -244,4 +244,4 @@ verbose: false
 Contributors are welcome to improve the CLI by submitting pull requests or reporting issues. For more details, check the project's GitHub repository.
 
 ## 📜 License
-The PR Pilot CLI is open-source software licensed under the GPL-3 license.
+The Arcane Engine CLI is open-source software licensed under the GPL-3 license.

--- a/prompts/homebrew.md.jinja2
+++ b/prompts/homebrew.md.jinja2
@@ -4,4 +4,4 @@ Here is the new homebrew formula:
 {{ sh('poetry homebrew-formula --template=homebrew_formula.rb --output=-') }}
 ```
 
-Write the content to `Formula/arcane-engine-cli.rb`.
+Write the content to `Formula/arcane-cli.rb`.

--- a/prompts/homebrew.md.jinja2
+++ b/prompts/homebrew.md.jinja2
@@ -4,4 +4,4 @@ Here is the new homebrew formula:
 {{ sh('poetry homebrew-formula --template=homebrew_formula.rb --output=-') }}
 ```
 
-Write the content to `Formula/pr-pilot-cli.rb`.
+Write the content to `Formula/arcane-engine-cli.rb`.

--- a/prompts/slack-report.md.jinja2
+++ b/prompts/slack-report.md.jinja2
@@ -17,7 +17,7 @@ Your summaries should be:
 
 # New Linear issues since yesterday
 {% set prompt %}
-1. Find all linear issues (title, description, url) created since yesterday 7am PST for team "PR Pilot"
+1. Find all linear issues (title, description, url) created since yesterday 7am PST for team "Arcane Engine"
 2. Read and understand every issue you found
 3. Identify common topics / parts of the code that are affected
 4. Summarize the issues by topics, with in-line links for easy access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "arcane-engine-cli"
+name = "arcane-cli"
 version = "1.20.2"
 description = "CLI for Arcane Engine, a text-to-task automation platform."
 authors = ["Marco Lamina <marco@arcane.engineer>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
-name = "pr-pilot-cli"
+name = "arcane-engine-cli"
 version = "1.20.2"
-description = "CLI for PR Pilot, a text-to-task automation platform."
+description = "CLI for Arcane Engine, a text-to-task automation platform."
 authors = ["Marco Lamina <marco@arcane.engineer>"]
 license = "GPL-3.0"
 readme = "README.md"
 packages = [{include = "cli"}]
-documentation = "https://docs.pr-pilot.ai"
-homepage = "https://www.pr-pilot.ai"
+documentation = "https://docs.arcane.engineer"
+homepage = "https://arcane.engineer"
 repository = "https://github.com/arc-eng/cli"
 
 [tool.black]


### PR DESCRIPTION
This pull request renames the project from PR Pilot to Arcane Engine, reflecting the new branding and identity.

**🔧 Configuration Changes**
- Updated repository references in [.pilot-commands.yaml](https://github.com/arc-eng/cli/blob/rename/.pilot-commands.yaml) to `arc-eng/cli`.

**📄 Documentation Updates**
- Replaced all instances of "PR Pilot" with "Arcane Engine" in [.pilot-hints.md](https://github.com/arc-eng/cli/blob/rename/.pilot-hints.md) and [README.md](https://github.com/arc-eng/cli/blob/rename/README.md).

**🛠️ Code Adjustments**
- Modified CLI help messages and descriptions in [cli/cli.py](https://github.com/arc-eng/cli/blob/rename/cli/cli.py) and other command files to reflect the new name.

**📦 Package Metadata**
- Updated `pyproject.toml` to change the package name to `arcane-cli` and updated URLs to the new domain.